### PR TITLE
Removed note about Outlook.com accounts

### DIFF
--- a/docs/includes/rest/app-registration-intro.md
+++ b/docs/includes/rest/app-registration-intro.md
@@ -17,5 +17,4 @@
 > 
 > ### REST API availability
 > 
-> The REST API is currently enabled on all Office 365 accounts that have Exchange Online, and some Outlook.com accounts. Microsoft accounts with Outlook.com mailboxes (including Outlook.com, Hotmail.com, Live.com, MSN.com, and Passport.com) are in the process of being upgraded to enable the REST APIs. During this process, making API calls to mailboxes that are not yet upgraded will return a MailboxNotEnabledForRESTAPI or MailboxNotSupportedForRESTAPI error code.
-> If you want to use the REST APIs with your existing Outlook.com mailbox and you are receiving a MailboxNotEnabledForRESTAPI or MailboxNotSupportedForRESTAPI error code, your account has not yet been upgraded. Rest assured that your account will be upgraded in a future batch. In the meantime, you can sign up for a new account [here](https://signup.live.com/signup?wa=wsignin1.0&rpsnv=12&ct=1454618383&rver=6.4.6456.0&wp=MBI_SSL_SHARED&wreply=https://mail.live.com/default.aspx&id=64855&cbcxt=mai&bk=1454618383&uiflavor=web&uaid=b213a65b4fdc484382b6622b3ecaa547&mkt=E-US&lc=1033&lic=1). All new accounts are enabled for the REST API immediately!
+> The REST API is currently enabled on all Office 365 accounts that have Exchange Online, and all Outlook.com accounts.

--- a/docs/rest/index.md
+++ b/docs/rest/index.md
@@ -44,9 +44,6 @@ Take an early look at the following services in preview status:
 
 Plan to upgrade in-production Office 365 apps once the preview period is over.
 
-> [!TIP]
-> Make sure Outlook.com apps handle user mailboxes that have not been enabled for the Outlook REST API. API calls made against these users will return either `MailboxNotEnabledForRESTAPI` or `MailboxNotSupportedForRESTAPI` error codes. See [Use the Outlook REST API](https://msdn.microsoft.com/office/office365/APi/use-outlook-rest-api#outlookrestcaution) for more information.
-
 ### Outlook REST API via Microsoft Graph
 
 Use one common REST endpoint -


### PR DESCRIPTION
All Outlook.com accounts now support the REST API, so removed the note about migration.