### PR TITLE
applying office365 tag

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -34,7 +34,7 @@
     "globalMetadata": {
       "uhfHeaderId": "MSDocsHeader-Outlook",
       "searchScope": [ "Outlook Developer" ],
-      "ms.suite": "Office",
+      "ms.suite": "office365",
       "ms.prod": "Outlook",
       "breadcrumb_path": "/outlook/breadcrumb/toc.json"
     },


### PR DESCRIPTION
Changed ms.suite tag to 'office365' so that all docs are using the same value and appear in reports together.