### PR TITLE
Making master the default branch from docs

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -1,6 +1,7 @@
 {
   "need_generate_pdf": false,
   "need_generate_intellisense": false,
+  "git_repository_branch_open_to_public_contributors": "master",
   "docsets_to_publish": [
     {
       "docset_name": "outlook",


### PR DESCRIPTION
I’ve noticed in another PR that you had to manually change the branch to master because docs is pointing to live. This should fix that problem. 