### PR TITLE
Removed X-AnchorMailbox from REST tutorials

### DIFF
--- a/docs/rest/ios-tutorial.md
+++ b/docs/rest/ios-tutorial.md
@@ -6,7 +6,7 @@ author: jasonjoh
 ms.topic: get-started-article
 ms.technology: ms-graph
 ms.devlang: swift
-ms.date: 10/23/2017
+ms.date: 02/20/2018
 ms.author: jasonjoh
 ---
 

--- a/docs/rest/ios-tutorial.md
+++ b/docs/rest/ios-tutorial.md
@@ -354,11 +354,6 @@ func makeApiCall(api: String, params: [String: String]? = nil, callback: @escapi
     
     var req = oauth2.request(forURL: apiUrl)
     req.addValue("application/json", forHTTPHeaderField: "Accept")
-    if (!userEmail.isEmpty) {
-        // Add X-AnchorMailbox header to optimize
-        // API routing
-        req.addValue(userEmail, forHTTPHeaderField: "X-AnchorMailbox")
-    }
     
     let loader = OAuth2DataLoader(oauth2: oauth2)
 
@@ -389,7 +384,6 @@ Let's look at what this function does.
 
 - It builds the API request URL, starting with a base of `https://graph.microsoft.com`, and adding whatever API string is passed in (e.g. `/v1.0/me`).
 - If any query parameters are passed in, it appends those to the URL as well (e.g. `$top` or `$select` parameters).
-- If we know the user's email address, it sets the `X-AnchorMailbox` header on the request. Setting this header to the user's email address allows the API endpoint to route API calls to the appropriate backend mailbox server more efficiently.
 - It creates an `OAuth2DataLoader` object to handle sending the request with authentication. The benefit to doing this is that the `OAuth2DataLoader` object will handle adding the access token to the request, and will automatically handle refreshing the token if needed.
 - It wraps the response using the SwiftyJSON library and calls the callback function.
 

--- a/docs/rest/java-tutorial.md
+++ b/docs/rest/java-tutorial.md
@@ -6,7 +6,7 @@ author: jasonjoh
 ms.topic: get-started-article
 ms.technology: ms-graph
 ms.devlang: java
-ms.date: 04/26/2017
+ms.date: 02/20/2018
 ms.author: jasonjoh
 ---
 
@@ -1364,11 +1364,7 @@ public class OutlookServiceBuilder {
             .header("return-client-request-id", "true")
             .header("Authorization", String.format("Bearer %s", accessToken))
             .method(original.method(), original.body());
-        
-        if (userEmail != null && !userEmail.isEmpty()) {
-          builder = builder.header("X-AnchorMailbox", userEmail);
-        }
-        
+
         Request request = builder.build();
         return chain.proceed(request);
       }
@@ -1485,7 +1481,6 @@ Now if you save all of your changes, restart the app, then login, you should end
 User-Agent: java-tutorial
 client-request-id: 3d42cd86-f74b-40d9-9dd3-031de58fec0f
 return-client-request-id: true
-X-AnchorMailbox: AllieB@contoso.com
 Authorization: Bearer eyJ0eXAiOiJK...
 --> END GET
 ```

--- a/docs/rest/node-tutorial.md
+++ b/docs/rest/node-tutorial.md
@@ -6,7 +6,7 @@ author: jasonjoh
 ms.topic: get-started-article
 ms.technology: ms-graph
 ms.devlang: nodejs
-ms.date: 01/23/2018
+ms.date: 02/20/2018
 ms.author: jasonjoh
 ---
 

--- a/docs/rest/node-tutorial.md
+++ b/docs/rest/node-tutorial.md
@@ -283,49 +283,7 @@ async function getTokenFromCode(auth_code, callback, response) {
 exports.getTokenFromCode = getTokenFromCode;
 ```
 
-### Getting the user's email address ###
-
-Our first use of the access token will be to get the user's email address from the Microsoft Graph API. You'll see why we want this soon.
-
-In order to use the Microsoft Graph API, install the [Microsoft Graph JavaScript Client Library](https://github.com/microsoftgraph/msgraph-sdk-javascript) from the command line.
-
-```Shell
-npm install @microsoft/microsoft-graph-client es6-promise --save
-```
-
-Then require the `microsoft-graph-client` library by adding the following line to `index.js`.
-
-```js
-const microsoftGraph = require("@microsoft/microsoft-graph-client");
-```
-
-Add a new function `getUserEmail` to `index.js`.
-
-#### `getUserEmail` in the `.\index.js` file ####
-
-```js
-async function getUserEmail(token) {
-  // Create a Graph client
-  const client = microsoftGraph.Client.init({
-    authProvider: (done) => {
-      // Just return the token
-      done(null, token);
-    }
-  });
-
-  // Get the Graph /Me endpoint to get user email address
-  const res = await client
-    .api('/me')
-    .get();
-
-  // Office 365 users have a mail attribute
-  // Outlook.com users do not, instead they have
-  // userPrincipalName
-  return res.mail ? res.mail : res.userPrincipalName;
-}
-```
-
-Let's make sure that works. Modify the `authorize` function in the `index.js` file to use these helper functions and display the return values.
+Let's make sure that works. Modify the `authorize` function in the `index.js` file to use this helper function and display the return value.
 #### Updated `authorize` function in `.\index.js`
 
 ```js
@@ -344,43 +302,33 @@ function authorize(response, request) {
 
 ```js
 async function processAuthCode(response, code) {
-  let token,email;
+  let token;
 
   try {
     token = await authHelper.getTokenFromCode(code);
   } catch(error){
     console.log('Access token error: ', error.message);
     response.writeHead(200, {'Content-Type': 'text/html'});
-    response.write(`<p>ERROR: ${error}</p>`);
-    response.end();
-    return;
-  }
-
-  try {
-    email = await getUserEmail(token.token.access_token);
-  } catch(error){
-    console.log(`getUserEmail returned an error: ${error}`);
     response.write(`<p>ERROR: ${error}</p>`);
     response.end();
     return;
   }
 
   response.writeHead(200, {'Content-Type': 'text/html'});
-  response.write('<p>Email: ' + email + '</p>');
   response.write('<p>Access token: ' + token.token.access_token + '</p>');
   response.end();
 }
 ```
 
-If you save your changes, restart the server, and go through the sign-in process again, you should now see the user's email and a long string of seemingly nonsensical characters. If everything's gone according to plan, that should be an access token.
+If you save your changes, restart the server, and go through the sign-in process again, you should now see long string of seemingly nonsensical characters. If everything's gone according to plan, that should be an access token.
 
-Now let's change our code to store the token and email in a session cookie instead of displaying them.
+Now let's change our code to store the token in a session cookie instead of displaying it.
 
 #### New version of `processAuthCode` function ####
 
 ```js
 async function processAuthCode(response, code) {
-  let token,email;
+  let token;
 
   try {
     token = await authHelper.getTokenFromCode(code);
@@ -392,17 +340,7 @@ async function processAuthCode(response, code) {
     return;
   }
 
-  try {
-    email = await getUserEmail(token.token.access_token);
-  } catch(error){
-    console.log(`getUserEmail returned an error: ${error}`);
-    response.write(`<p>ERROR: ${error}</p>`);
-    response.end();
-    return;
-  }
-
-  const cookies = [`node-tutorial-token=${token.token.access_token};Max-Age=4000`,
-                   `node-tutorial-email=${email ? email : ''}';Max-Age=4000`];
+  const cookies = [`node-tutorial-token=${token.token.access_token};Max-Age=4000`];
   response.setHeader('Set-Cookie', cookies);
   response.writeHead(302, {'Location': 'http://localhost:8000/mail'});
   response.end();
@@ -444,7 +382,7 @@ This will cause the token response from Azure to include a refresh token. Let's 
 
 ```js
 async function tokenReceived(response, error, token) {
-  let token,email;
+  let token;
 
   try {
     token = await authHelper.getTokenFromCode(code);
@@ -456,19 +394,9 @@ async function tokenReceived(response, error, token) {
     return;
   }
 
-  try {
-    email = await getUserEmail(token.token.access_token);
-  } catch(error){
-    console.log(`getUserEmail returned an error: ${error}`);
-    response.write(`<p>ERROR: ${error}</p>`);
-    response.end();
-    return;
-  }
-
   const cookies = [`node-tutorial-token=${token.token.access_token};Max-Age=4000`,
                    `node-tutorial-refresh-token=${token.token.refresh_token};Max-Age=4000`,
-                   `node-tutorial-token-expires=${token.token.expires_at.getTime()};Max-Age=4000`,
-                   `node-tutorial-email=${email ? email : ''}';Max-Age=4000`];
+                   `node-tutorial-token-expires=${token.token.expires_at.getTime()};Max-Age=4000`];
   response.setHeader('Set-Cookie', cookies);
   response.writeHead(302, {'Location': 'http://localhost:8000/mail'});
   response.end();
@@ -515,7 +443,21 @@ exports.refreshAccessToken = refreshAccessToken;
 
 ## Using the Mail API ##
 
-Now that we can get an access token, we're in a good position to do something with the Mail API. Let's start by creating a `mail` route and function. Open the `index.js` file and update the `handle` array.
+Now that we can get an access token, we're in a good position to do something with the Mail API.
+
+In order to use the Microsoft Graph API, install the [Microsoft Graph JavaScript Client Library](https://github.com/microsoftgraph/msgraph-sdk-javascript) from the command line.
+
+```Shell
+npm install @microsoft/microsoft-graph-client es6-promise --save
+```
+
+Then require the `microsoft-graph-client` library by adding the following line to `index.js`.
+
+```js
+const microsoftGraph = require("@microsoft/microsoft-graph-client");
+```
+
+Let's start by creating a `mail` route and function. Open the `index.js` file and update the `handle` array.
 
 #### Updated handle array in `.\index.js`
 
@@ -567,8 +509,6 @@ async function mail(response, request) {
   }
 
   console.log('Token found in cookie: ', token);
-  const email = getValueFromCookie('node-tutorial-email', request.headers.cookie);
-  console.log('Email found in cookie: ', email);
 
   response.writeHead(200, {'Content-Type': 'text/html'});
   response.write('<div><h1>Your inbox</h1></div>');
@@ -585,7 +525,6 @@ async function mail(response, request) {
     // Get the 10 newest messages
     const res = await client
       .api('/me/mailfolders/inbox/messages')
-      .header('X-AnchorMailbox', email)
       .top(10)
       .select('subject,from,receivedDateTime,isRead')
       .orderby('receivedDateTime DESC')
@@ -614,7 +553,6 @@ async function mail(response, request) {
 To summarize the new code in the `mail` function:
 
 - It creates a Graph client object and initializes it to use the access token passed to the function.
-- It sets the `X-AnchorMailbox` header on the request, which enables the API endpoint to route API calls to the appropriate backend mailbox server more efficiently. This is why we went to the trouble to get the user's email earlier.
 - It calls the `/me/mailfolders/inbox/messages` API to get inbox messages, and uses other methods to control the request:
     - It uses the `top` method with a value of `10` to limit the results to the first 10.
     - It uses the `select` method to only request the `subject`, `from`, `receivedDateTime`, and `isRead` properties.
@@ -671,7 +609,6 @@ Now that you've mastered calling the Outlook Mail API, doing the same for Calend
       // Get the 10 events with the greatest start date
       const res = await client
         .api('/me/events')
-        .header('X-AnchorMailbox', email)
         .top(10)
         .select('subject,start,end,attendees')
         .orderby('start/dateTime DESC')
@@ -754,7 +691,6 @@ Now that you've mastered calling the Outlook Mail API, doing the same for Calend
       // by given name
       const res = await client
           .api('/me/contacts')
-          .header('X-AnchorMailbox', email)
           .top(10)
           .select('givenName,surname,emailAddresses')
           .orderby('givenName ASC')

--- a/docs/rest/php-tutorial.md
+++ b/docs/rest/php-tutorial.md
@@ -6,7 +6,7 @@ author: jasonjoh
 ms.topic: get-started-article
 ms.technology: ms-graph
 ms.devlang: php
-ms.date: 02/21/2017
+ms.date: 02/21/2018
 ms.author: jasonjoh
 ---
 

--- a/docs/rest/php-tutorial.md
+++ b/docs/rest/php-tutorial.md
@@ -6,7 +6,7 @@ author: jasonjoh
 ms.topic: get-started-article
 ms.technology: ms-graph
 ms.devlang: php
-ms.date: 06/02/2017
+ms.date: 02/21/2017
 ms.author: jasonjoh
 ---
 
@@ -550,7 +550,7 @@ Run the following command from your command prompt/shell in the `php-tutorial` d
 composer update
 ```
 
-Now let's modify the `mail` function. Our first use of the Graph SDK here will be to get the user's name and email address. You'll see why we want this soon.
+Now let's modify the `mail` function. Our first use of the Graph SDK here will be to get the user's name, just to verify that we can call the Microsoft Graph API.
 
 Add the following lines just after the `use App\Http\Controllers\Controller;` line in `OutlookController.php`.
 
@@ -579,11 +579,11 @@ public function mail()
                 ->setReturnType(Model\User::class)
                 ->execute();
 
-  echo 'User: '.$user->getDisplayName().' - '.$user->getMail();
+  echo 'User: '.$user->getDisplayName();
 }
 ```
 
-Save your changes and refresh the mail view. You should see the authenticated user's name and email address. (If not, start over at `http://localhost:8000` and login again.)
+Save your changes and refresh the mail view. You should see the authenticated user's name. (If not, start over at `http://localhost:8000` and login again.)
 
 Now let's add code to retrieve the user's messages. Replace the existing `mail` function with the following.
 
@@ -605,7 +605,7 @@ public function mail()
                 ->setReturnType(Model\User::class)
                 ->execute();
 
-  echo 'User: '.$user->getDisplayName().' - '.$user->getMail().'<br/>';
+  echo 'User: '.$user->getDisplayName().'<br/>';
 
   $messageQueryParams = array (
     // Only return Subject, ReceivedDateTime, and From fields
@@ -618,7 +618,6 @@ public function mail()
 
   $getMessagesUrl = '/me/mailfolders/inbox/messages?'.http_build_query($messageQueryParams);
   $messages = $graph->createRequest('GET', $getMessagesUrl)
-                    ->addHeaders(array ('X-AnchorMailbox' => $user->getMail()))
                     ->setReturnType(Model\Message::class)
                     ->execute();
 
@@ -631,7 +630,6 @@ public function mail()
 To summarize the new code in the `mail` function:
 
 - It creates a Graph client object and initializes it to use the access token passed to the function.
-- It sets the `X-AnchorMailbox` header on the request, which enables the API endpoint to route API calls to the appropriate backend mailbox server more efficiently. This is why we went to the trouble to get the user's email earlier.
 - It calls the `/me/mailfolders/inbox/messages` API to get inbox messages, and uses other methods to control the request:
     - It uses the `top` method with a value of `10` to limit the results to the first 10.
     - It uses the `select` method to only request the `subject`, `from`, `receivedDateTime`, and `isRead` properties.
@@ -703,13 +701,11 @@ public function mail()
 
   $getMessagesUrl = '/me/mailfolders/inbox/messages?'.http_build_query($messageQueryParams);
   $messages = $graph->createRequest('GET', $getMessagesUrl)
-                    ->addHeaders(array ('X-AnchorMailbox' => $user->getMail()))
                     ->setReturnType(Model\Message::class)
                     ->execute();
 
   return view('mail', array(
     'username' => $user->getDisplayName(),
-    'usermail' => $user->getMail(),
     'messages' => $messages
   ));
 }
@@ -765,13 +761,11 @@ Now that you've mastered calling the Outlook Mail API, doing the same for Calend
 
       $getEventsUrl = '/me/events?'.http_build_query($eventsQueryParams);
       $events = $graph->createRequest('GET', $getEventsUrl)
-                      ->addHeaders(array ('X-AnchorMailbox' => $user->getMail()))
                       ->setReturnType(Model\Event::class)
                       ->execute();
 
       return view('calendar', array(
         'username' => $user->getDisplayName(),
-        'usermail' => $user->getMail(),
         'events' => $events
       ));
     }
@@ -858,13 +852,11 @@ Now that you've mastered calling the Outlook Mail API, doing the same for Calend
 
       $getContactsUrl = '/me/contacts?'.http_build_query($contactsQueryParams);
       $contacts = $graph->createRequest('GET', $getContactsUrl)
-                        ->addHeaders(array ('X-AnchorMailbox' => $user->getMail()))
                         ->setReturnType(Model\Contact::class)
                         ->execute();
 
       return view('contacts', array(
         'username' => $user->getDisplayName(),
-        'usermail' => $user->getMail(),
         'contacts' => $contacts
       ));
     }

--- a/docs/rest/ruby-tutorial.md
+++ b/docs/rest/ruby-tutorial.md
@@ -6,7 +6,7 @@ author: jasonjoh
 ms.topic: get-started-article
 ms.technology: ms-graph
 ms.devlang: ruby
-ms.date: 04/26/2017
+ms.date: 02/21/2018
 ms.author: jasonjoh
 ---
 
@@ -337,37 +337,7 @@ def get_token_from_code(auth_code)
 end
 ```
 
-### Getting the user's email address ###
-
-Our first use of the access token will be to get the user's email address from the Graph. You'll see why we want this soon. Let's start by installing the [Microsoft Graph Client Library for Ruby](https://github.com/microsoftgraph/msgraph-sdk-ruby). We'll be using this gem for all of our Outlook-related requests.
-
-Open up the `Gemfile` file and add this line anywhere in the file:
-
-```ruby
-gem 'microsoft_graph'
-```
-
-Save the file, run `bundle install`, and restart the server. 
-
-Add a new function `get_user_email` to `auth_helper.rb`.
-
-#### `get_user_email` in the `.\o365-tutorial\app\helpers\auth_helper.rb` file ####
-
-```ruby
-# Gets the user's email from the /Me endpoint
-def get_user_email(access_token)
-  callback = Proc.new { |r| r.headers['Authorization'] = "Bearer #{access_token}"}
-
-  graph = MicrosoftGraph.new(base_url: 'https://graph.microsoft.com/v1.0',
-                             cached_metadata_file: File.join(MicrosoftGraph::CACHED_METADATA_DIRECTORY, 'metadata_v1.0.xml'),
-                             &callback)
-
-  me = graph.me
-  email = me.mail
-end
-```
-
-Let's make sure that works. Modify the `gettoken` action in the `auth_controller.rb` file to use these helper functions and display the return values.
+Let's make sure that works. Modify the `gettoken` action in the `auth_controller.rb` file to use this helper function and display the return value.
 
 #### Updated contents of the `.\o365-tutorial\app\controllers\auth_controller.rb` file
 
@@ -376,15 +346,14 @@ class AuthController < ApplicationController
 
   def gettoken
   token = get_token_from_code params[:code]
-  email = get_user_email token.token
-  render text: "Email: #{email}, TOKEN: #{token.token}"
+  render text: "TOKEN: #{token.token}"
   end
 end
 ```
 
-If you save your changes and go through the sign-in process again, you should now see the user's email followed by a long string of seemingly nonsensical characters. If everything's gone according to plan, that should be an access token.
+If you save your changes and go through the sign-in process again, you should now see a long string of seemingly nonsensical characters. If everything's gone according to plan, that should be an access token.
 
-Now let's change our code to store the token and email in a session cookie instead of displaying them.
+Now let's change our code to store the token in a session cookie instead of displaying it.
 
 #### New version of `gettoken` action
 
@@ -392,7 +361,6 @@ Now let's change our code to store the token and email in a session cookie inste
 def gettoken
   token = get_token_from_code params[:code]
   session[:azure_token] = token.to_hash
-  session[:user_email] = get_user_email token.token
   render text: "Access token saved in session cookie."
 end
 ```
@@ -444,7 +412,17 @@ end
 
 ## Using the Mail API ##
 
-Now that we can get an access token, we're in a good position to do something with the Mail API. Let's start by creating a controller for mail operations.
+Now that we can get an access token, we're in a good position to do something with the Mail API. Let's start by installing the [Microsoft Graph Client Library for Ruby](https://github.com/microsoftgraph/msgraph-sdk-ruby). We'll be using this gem for all of our Outlook-related requests.
+
+Open up the `Gemfile` file and add this line anywhere in the file:
+
+```ruby
+gem 'microsoft_graph'
+```
+
+Save the file, run `bundle install`, and restart the server. 
+
+Now let's create a controller for mail operations.
 
 ```ruby
 rails generate controller Mail index
@@ -460,7 +438,6 @@ Now we can modify the `gettoken` action one last time to redirect to the index a
 def gettoken
   token = get_token_from_code params[:code]
   session[:azure_token] = token.to_hash
-  session[:user_email] = get_user_email token.token
   redirect_to mail_index_url
 end
 ```
@@ -478,13 +455,11 @@ class MailController < ApplicationController
 
   def index
     token = get_access_token
-    email = session[:user_email]
 
     if token
       # If a token is present in the session, get messages from the inbox
       callback = Proc.new do |r| 
         r.headers['Authorization'] = "Bearer #{token}"
-        r.headers['X-AnchorMailbox'] = email
       end
 
       graph = MicrosoftGraph.new(base_url: 'https://graph.microsoft.com/v1.0',
@@ -507,7 +482,6 @@ To summarize the code in the `index` action:
 - It issues a GET request to the URL for inbox messages, with the following characteristics:
     - It uses the `order_by` method to sort the results by `receivedDateTime`.
     - It sets the `Authorization` header to use the access token from Azure.
-    - It sets the `X-AnchorMailbox` header to the user's email address. Setting this header allows the API endpoint to route API calls to the appropriate backend mailbox server more efficiently.
 - It saves the return collection to the `@messages` variable. This variable will be available to the view template.
 
 ## Displaying the results
@@ -576,12 +550,10 @@ Now that you've mastered calling the Outlook Mail API, doing the same for Calend
       
       def index
         token = get_access_token
-        email = session[:user_email]
         if token
           # If a token is present in the session, get events from the calendar
           callback = Proc.new do |r| 
             r.headers['Authorization'] = "Bearer #{token}"
-            r.headers['X-AnchorMailbox'] = email
           end
 
           graph = MicrosoftGraph.new(base_url: 'https://graph.microsoft.com/v1.0',
@@ -647,12 +619,10 @@ Now that you've mastered calling the Outlook Mail API, doing the same for Calend
       
       def index
         token = get_access_token
-        email = session[:user_email]
         if token
           # If a token is present in the session, get contacts
           callback = Proc.new do |r| 
             r.headers['Authorization'] = "Bearer #{token}"
-            r.headers['X-AnchorMailbox'] = email
           end
 
           graph = MicrosoftGraph.new(base_url: 'https://graph.microsoft.com/v1.0',


### PR DESCRIPTION
Graph ignores this header, so setting it was useless. Removing this allowed the tutorials to be simplified and shortened.