### PR TITLE
Calendar API AppScopes in dotnet-tutorial.md

### DIFF
--- a/docs/rest/dotnet-tutorial.md
+++ b/docs/rest/dotnet-tutorial.md
@@ -834,7 +834,7 @@ Now that you've mastered calling the Outlook Mail API, doing the same for Calend
 
 ### For Calendar API:
 
-1. Update the `ida:AppScopes` value in `Web.config` to include the `Calendars.Read` scope.
+1. Update the `ida:AppScopes` value in `AzureOauth.config` to include the `Calendars.Read` scope.
 
     ```xml
     <add key="ida:AppScopes" value="User.Read Mail.Read Calendars.Read" />


### PR DESCRIPTION
Wrong file was mentioned. AzureOauth.config was referenced in the web.config before so the setting is to be updated there.