### PR TITLE
Support TLS 1.2

### DIFF
--- a/.openpublishing.build.ps1
+++ b/.openpublishing.build.ps1
@@ -9,6 +9,8 @@ $errorActionPreference = 'Stop'
 echo "download build core script to local with source url: $buildCorePowershellUrl"
 $repositoryRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
 $buildCorePowershellDestination = "$repositoryRoot\.openpublishing.buildcore.ps1"
+# Use TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest $buildCorePowershellUrl -OutFile "$buildCorePowershellDestination"
 
 # Step-2: Run build core


### PR DESCRIPTION
PowerShell by default uses TLS 1.0 for all Rest API requests, which is vulnerable to [POODLE](https://githubengineering.com/crypto-deprecation-notice/) and other crypto vulnerabilities. Applying this change will force supporting TLS 1.2 and prevent having the following error:
```PowerShell
The request was aborted: Could not create SSL/TLS secure channel.
```

This update also (permanently) fixes [#358](https://github.com/OfficeDev/outlook-dev-docs/issues/358), which worked on Azure portal since TLS 1.2 is already supported there.