### PR TITLE
Fix typo in 'Use regular expression activation rules to show an Outlook add-in' article

### DIFF
--- a/docs/add-ins/use-regular-expressions-to-show-an-outlook-add-in.md
+++ b/docs/add-ins/use-regular-expressions-to-show-an-outlook-add-in.md
@@ -141,7 +141,7 @@ The following is an example of a rule collection that contains an  `ItemHasRegul
 ```XML
 <Rule xsi:type="RuleCollection" Mode="And">
     <Rule xsi:type="ItemIs" ItemType="Message"/>
-    <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="videoURL" RegExValue="http://www\.youtube\.com/watch\?v=[a-zA-Z0-9_-]{11}" PropertyName="BodyAsHtml"/>
+    <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="videoURL" RegExValue="http://www\.youtube\.com/watch\?v=[a-zA-Z0-9_-]{11}" PropertyName="BodyAsHTML"/>
 </Rule>
 ```
 

--- a/docs/add-ins/use-regular-expressions-to-show-an-outlook-add-in.md
+++ b/docs/add-ins/use-regular-expressions-to-show-an-outlook-add-in.md
@@ -141,7 +141,7 @@ The following is an example of a rule collection that contains an  `ItemHasRegul
 ```XML
 <Rule xsi:type="RuleCollection" Mode="And">
     <Rule xsi:type="ItemIs" ItemType="Message"/>
-    <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="videoURL" RegExValue="http://www\.youtube\.com/watch\?v=[a-zA-Z0-9_-]{11}" PropertyName="BodyAsHTML"/>
+    <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="videoURL" RegExValue="http://www\.youtube\.com/watch\?v=[a-zA-Z0-9_-]{11}" PropertyName="BodyAsPlaintext"/>
 </Rule>
 ```
 

--- a/docs/add-ins/use-regular-expressions-to-show-an-outlook-add-in.md
+++ b/docs/add-ins/use-regular-expressions-to-show-an-outlook-add-in.md
@@ -141,7 +141,7 @@ The following is an example of a rule collection that contains an  `ItemHasRegul
 ```XML
 <Rule xsi:type="RuleCollection" Mode="And">
     <Rule xsi:type="ItemIs" ItemType="Message"/>
-    <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="videoURL" RegExValue="http://www\.youtube\.com/watch\?v=[a-zA-Z0-9_-]{11}" PropertyName="Body"/>
+    <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="videoURL" RegExValue="http://www\.youtube\.com/watch\?v=[a-zA-Z0-9_-]{11}" PropertyName="BodyAsHtml"/>
 </Rule>
 ```
 


### PR DESCRIPTION
Fixes issue #371 