### PR TITLE
Fix `on click` wiring up

### DIFF
--- a/docs/add-ins/addin-tutorial.md
+++ b/docs/add-ins/addin-tutorial.md
@@ -584,9 +584,9 @@ function buildGistList(parent, gists, clickFunc) {
       .attr('type', 'hidden')
       .val(gist.id)
       .appendTo(listItem);
-  });
-
-  $('.ms-ListItem').on('click', clickFunc);
+      
+      listItem.on('click', clickFunc);
+  });  
 }
 
 function buildFileList(files) {


### PR DESCRIPTION
use `listItem` directly to set the `click` event otherwise it won't fire when the user click on the gist item in the list.

---
#### Document Details

⚠ *Do not edit this section. It is required for docs.microsoft.com ➟ GitHub issue linking.*

* ID: 2b98fcab-f608-d0dd-08ab-633d4772f699
* Version Independent ID: ad0a00c9-e5c2-fdfc-732e-f14869088f4a
* Content: [Tutorial: Build a message compose Outlook add-in - Outlook Developer](https://docs.microsoft.com/en-us/outlook/add-ins/addin-tutorial)
* Content Source: [docs/add-ins/addin-tutorial.md](https://github.com/OfficeDev/outlook-dev-docs/blob/master/docs/add-ins/addin-tutorial.md)
* Product: **outlook**
* GitHub Login: @jasonjoh