### PR TITLE
[Admin] Fix typos.

### DIFF
--- a/docs/actionable-messages/invoke-add-in.md
+++ b/docs/actionable-messages/invoke-add-in.md
@@ -20,7 +20,7 @@ Actionable messages allow the user to take quick actions on an email message or 
 `Action.InvokeAddInCommand` actions can work with add-ins that are already installed by the user, or they can work with add-ins that are not installed. If the required add-in is not installed, the user is prompted to install the add-in with a single click.
 
 > [!NOTE]
-> Single-click installation of the required add-in is only supported if the add-in is published in the [AppSource](https://docs.microsoft.com/office/dev/store/submit-to-the-office-store).
+> Single-click installation of the required add-in is only supported if the add-in is published in [AppSource](/office/dev/store/submit-to-the-office-store).
 
 The following example shows the prompt users see if the add-in is not installed.
 

--- a/docs/actionable-messages/invoke-add-in.md
+++ b/docs/actionable-messages/invoke-add-in.md
@@ -20,7 +20,7 @@ Actionable messages allow the user to take quick actions on an email message or 
 `Action.InvokeAddInCommand` actions can work with add-ins that are already installed by the user, or they can work with add-ins that are not installed. If the required add-in is not installed, the user is prompted to install the add-in with a single click.
 
 > [!NOTE]
-> Single-click installation of the required add-in is only supported if the add-in is published in the [Office Store](https://docs.microsoft.com/office/dev/store/submit-to-the-office-store).
+> Single-click installation of the required add-in is only supported if the add-in is published in the [AppSource](https://docs.microsoft.com/office/dev/store/submit-to-the-office-store).
 
 The following example shows the prompt users see if the add-in is not installed.
 

--- a/docs/add-ins/add-in-requirements.md
+++ b/docs/add-ins/add-in-requirements.md
@@ -31,7 +31,7 @@ If the user is connected to Office 365 or Outlook.com, mail server requirements 
 - The server must be Exchange 2013 or later.
 - Exchange Web Services (EWS) must be enabled and must be exposed to the Internet. Many add-ins require EWS to function properly.
 - The server must have a valid authentication certificate in order for the server to issue valid identity tokens. New installations of Exchange Server include a default authentication certificate. For more information, see [Digital certificates and encryption in Exchange 2016](https://technet.microsoft.com/en-us/library/dd351044(v=exchg.160).aspx) and [Set-AuthConfig](/powershell/module/exchange/organization/Set-AuthConfig?view=exchange-ps).
-- To access add-ins from the [Office Store](https://appsource.microsoft.com/marketplace/apps?product=office&page=1&src=office&corrid=a35323d5-0e3d-4cc0-ba44-57537d74aae8&omexanonuid=581941df-1c6f-4eda-89e7-651af8aeaeb2), the client access servers must be able to communicate with AppSource.
+- To access add-ins from [AppSource](https://appsource.microsoft.com/marketplace/apps?product=office&page=1&src=office&corrid=a35323d5-0e3d-4cc0-ba44-57537d74aae8&omexanonuid=581941df-1c6f-4eda-89e7-651af8aeaeb2), the client access servers must be able to communicate with AppSource.
 
 ## Add-in server requirements
 

--- a/docs/add-ins/apis.md
+++ b/docs/add-ins/apis.md
@@ -12,7 +12,7 @@ To use APIs in your Outlook add-in, you must specify the location of the Office.
 
 ## Office.js library
 
-To interact with the Outlook add-in API, you need to use the JavaScript APIs in Office.js. The CDN for the library is `https://appsforoffice.microsoft.com/lib/1/hosted/Office.js`. Add-ins submitted to the Office Store must reference Office.js by this CDN; they can't use a local reference.
+To interact with the Outlook add-in API, you need to use the JavaScript APIs in Office.js. The CDN for the library is `https://appsforoffice.microsoft.com/lib/1/hosted/Office.js`. Add-ins submitted to AppSource must reference Office.js by this CDN; they can't use a local reference.
 
 Reference the CDN in a `<script>` tag in the `<head>` tag of the web page (.html, .aspx, or .php file) that implements the UI of your add-in.
 

--- a/docs/add-ins/authenticate-a-user-with-an-sso-token.md
+++ b/docs/add-ins/authenticate-a-user-with-an-sso-token.md
@@ -30,7 +30,7 @@ To use SSO, your Outlook add-in will need to have a server-side web API that is 
 
 ### Provide consent when sideloading an add-in
 
-When an add-in that uses SSO is acquired from the Office Store, the store UI handles prompting the user for consent to the requested Graph permissions. However, when you are developing an add-in, you have to provide consent in advance. For more information, see [Grant administrator consent to the add-in](/office/dev/add-ins/develop/grant-admin-consent-to-an-add-in)
+When an add-in that uses SSO is acquired from AppSource, the store UI handles prompting the user for consent to the requested Graph permissions. However, when you are developing an add-in, you have to provide consent in advance. For more information, see [Grant administrator consent to the add-in](/office/dev/add-ins/develop/grant-admin-consent-to-an-add-in)
 
 ## Update the add-in manifest
 

--- a/docs/add-ins/index.md
+++ b/docs/add-ins/index.md
@@ -12,14 +12,14 @@ Outlook add-ins are integrations built by third parties into Outlook by using ou
 
 - The same add-in and business logic works across desktop (Outlook on Windows and Mac), web (Office 365 and Outlook.com), and mobile.
 - Outlook add-ins consist of a manifest, which describes how the add-in integrates into Outlook (for example, a button or a task pane), and JavaScript/HTML code, which makes up the UI and business logic of the add-in.
-- Outlook add-ins can be acquired from the Office store or [side-loaded](sideload-outlook-add-ins-for-testing.md) by end-users or administrators.
+- Outlook add-ins can be acquired from [AppSource](https://appsource.microsoft.com) or [sideloaded](sideload-outlook-add-ins-for-testing.md) by end-users or administrators.
 
 Outlook add-ins are different from COM or VSTO add-ins, which are older integrations specific to Outlook running on Windows. Unlike COM add-ins, Outlook add-ins don't have any code physically installed on the user's device or Outlook client. For an Outlook add-in, Outlook reads the manifest and hooks up the specified controls in the UI, and then loads the JavaScript and HTML. The web components all run in the context of a browser in a sandbox.
 
 The Outlook items that support add-ins include email messages, meeting requests, responses and cancellations, and appointments. Each Outlook add-in defines the context in which it is available, including the types of items and if the user is reading or composing an item.
 
 > [!NOTE]
-> When you build your add-in, if you plan to [publish](/office/dev/add-ins/publish/publish?product=outlook) your add-in to the Office Store, make sure that you conform to the [Office Store validation policies](/office/dev/store/validation-policies). For example, to pass validation, your add-in must work across all platforms that support the methods that you define (for more information, see [section 4.12](/office/dev/store/validation-policies#4-apps-and-add-ins-behave-predictably) and the [Office Add-in host and availability page](/office/dev/add-ins/overview/office-add-in-availability)).
+> When you build your add-in, if you plan to [publish](/office/dev/add-ins/publish/publish?product=outlook) your add-in to AppSource, make sure that you conform to the [AppSource validation policies](/office/dev/store/validation-policies). For example, to pass validation, your add-in must work across all platforms that support the methods that you define (for more information, see [section 4.12](/office/dev/store/validation-policies#4-apps-and-add-ins-behave-predictably) and the [Office Add-in host and availability page](/office/dev/add-ins/overview/office-add-in-availability)).
 
 ## Extension points
 

--- a/docs/add-ins/outlook-mobile-addins.md
+++ b/docs/add-ins/outlook-mobile-addins.md
@@ -24,7 +24,7 @@ Outlook mobile add-ins are supported on all Office 365 Commercial accounts, Outl
 
 ## What's different on mobile?
 
-- The small size and quick interactions make designing for mobile a challenge. To ensure quality experiences for our customers, we are setting strict validation criteria that must be met by an add-in declaring mobile support, in order to be approved in the Office Store.
+- The small size and quick interactions make designing for mobile a challenge. To ensure quality experiences for our customers, we are setting strict validation criteria that must be met by an add-in declaring mobile support, in order to be approved in AppSource.
     - The add-in **MUST** adhere to the [UI guidelines](outlook-addin-design.md).
     - The scenario for the add-in **MUST** [make sense on mobile](#what-makes-a-good-scenario-for-mobile-add-ins).
 
@@ -58,7 +58,7 @@ Here are examples of scenarios that make sense in Outlook Mobile.
 
 ## Testing your add-ins on mobile
 
-To test an add-in on Outlook Mobile, you can side-load an add-in to an O365 or Outlook.com account. In Outlook on the web, go to the settings gear, and choose **Manage Integrations** or **Manage Add-ins**. Near the top, click where it says **Click here to add a custom add-in** and upload your manifest. Make sure your manifest is properly formatted to contain `MobileFormFactor` or it won't load.
+To test an add-in on Outlook Mobile, you can sideload an add-in to an O365 or Outlook.com account. In Outlook on the web, go to the settings gear, and choose **Manage Integrations** or **Manage Add-ins**. Near the top, click where it says **Click here to add a custom add-in** and upload your manifest. Make sure your manifest is properly formatted to contain `MobileFormFactor` or it won't load.
 
 After your add-in is working, make sure to test it on different screen sizes, including phones and tablets. You should make sure it meets accessibility guidelines for contrast, font size, and color, as well as being usable with a screen reader such as VoiceOver on iOS or TalkBack on Android.
 

--- a/docs/add-ins/outlook-on-send-addins.md
+++ b/docs/add-ins/outlook-on-send-addins.md
@@ -226,17 +226,17 @@ In the `Contoso Message Body Checker.xml` manifest file, you include the functio
 
 ```xml
 <Hosts>
-        <Host xsi:type="MailHost">
-          <DesktopFormFactor>
+    <Host xsi:type="MailHost">
+        <DesktopFormFactor>
             <!-- The functionfile and function name to call on message send.  -->
             <!-- In this case, the function validateBody will be called within the JavaScript code referenced in residUILessFunctionFileUrl. -->
             <FunctionFile resid="residUILessFunctionFileUrl" />
             <ExtensionPoint xsi:type="Events">
-              <Event Type="ItemSend" FunctionExecution="synchronous" FunctionName="validateBody" />
+                <Event Type="ItemSend" FunctionExecution="synchronous" FunctionName="validateBody" />
             </ExtensionPoint>
-          </DesktopFormFactor>
-        </Host>
-      </Hosts>
+        </DesktopFormFactor>
+    </Host>
+</Hosts>
 ```
 
 > [!IMPORTANT]
@@ -248,17 +248,17 @@ For the `Contoso Subject and CC Checker.xml` manifest file, the following exampl
 
 ```xml
 <Hosts>
-        <Host xsi:type="MailHost">
-          <DesktopFormFactor>
+    <Host xsi:type="MailHost">
+        <DesktopFormFactor>
             <!-- The functionfile and function name to call on message send.  -->
             <!-- In this case the function validateSubjectAndCC will be called within the JavaScript code referenced in residUILessFunctionFileUrl. -->
             <FunctionFile resid="residUILessFunctionFileUrl" />
             <ExtensionPoint xsi:type="Events">
-              <Event Type="ItemSend" FunctionExecution="synchronous" FunctionName="validateSubjectAndCC" />
+                <Event Type="ItemSend" FunctionExecution="synchronous" FunctionName="validateSubjectAndCC" />
             </ExtensionPoint>
-          </DesktopFormFactor>
-        </Host>
-      </Hosts>
+        </DesktopFormFactor>
+    </Host>
+</Hosts>
 ```
 
 <br/>
@@ -267,10 +267,12 @@ The on send API requires **VersionOverrides v1_1**. The following shows you how 
 
 ```xml
  <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
-    <!-- On Send requires VersionOverridesV1_1 -->
-    <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
+     <!-- On Send requires VersionOverridesV1_1 -->
+     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
+         ...
+     </VersionOverrides>
+</VersionOverrides>
 ```
-
 
 > [!NOTE]
 > For more information, see the following:
@@ -284,17 +286,17 @@ The on send API requires **VersionOverrides v1_1**. The following shows you how 
 To access the currently selected message (in this example, the newly composed  message), use the **Office.context.mailbox.item** namespace. The **ItemSend** event is automatically passed by the on send feature to the function specified in the manifest&mdash;in this example, the `validateBody`function.
 
 ```js
- var mailboxItem;
+var mailboxItem;
 
-    Office.initialize = function (reason) {
-        mailboxItem = Office.context.mailbox.item;
-    }
+Office.initialize = function (reason) {
+    mailboxItem = Office.context.mailbox.item;
+}
 
-    // Entry point for Contoso Message Body Checker add-in before send is allowed.
-    // <param name="event">ItemSend event is automatically passed by on send code to the function specified in the manifest.</param>
-    function validateBody(event) {
-        mailboxItem.body.getAsync("html", { asyncContext: event }, checkBodyOnlyOnSendCallBack);
-    }
+// Entry point for Contoso Message Body Checker add-in before send is allowed.
+// <param name="event">ItemSend event is automatically passed by on send code to the function specified in the manifest.</param>
+function validateBody(event) {
+    mailboxItem.body.getAsync("html", { asyncContext: event }, checkBodyOnlyOnSendCallBack);
+}
 ```
 
 The `validateBody` function gets the current body in the specified format (HTML) and passes the **ItemSend** event object that the code wants to access in the callback method. In addition to the **getAsync** method, the **Body** object also provides a **setAsync** method that you can use to replace the body with the specified text.
@@ -308,26 +310,26 @@ The `validateBody` function gets the current body in the specified format (HTML)
 The `checkBodyOnlyOnSendCallBack` function uses a regular expression to determine whether the message body contains blocked words. If it finds a match against an array of restricted words, it then blocks the email from being sent and notifies the sender via the information bar. To do this, it uses the **notificationMessages** property of the **Item** object to return a **NotificationMessages** object. It then adds a notification to the item by calling the **addAsync** method, as shown in the following example.
 
 ```js
-  // Determine whether the body contains a specific set of blocked words. If it contains the blocked words, block email from being sent. Otherwise allow sending.
-    // <param name="asyncResult">ItemSend event passed from the calling function.</param>
-    function checkBodyOnlyOnSendCallBack(asyncResult) {
-        var listOfBlockedWords = new Array("blockedword", "blockedword1", "blockedword2");
-        var wordExpression = listOfBlockedWords.join('|');
+// Determine whether the body contains a specific set of blocked words. If it contains the blocked words, block email from being sent. Otherwise allow sending.
+// <param name="asyncResult">ItemSend event passed from the calling function.</param>
+function checkBodyOnlyOnSendCallBack(asyncResult) {
+    var listOfBlockedWords = new Array("blockedword", "blockedword1", "blockedword2");
+    var wordExpression = listOfBlockedWords.join('|');
 
-        // \b to perform a "whole words only" search using a regular expression in the form of \bword\b.
-        // i to perform case-insensitive search.
-        var regexCheck = new RegExp('\\b(' + wordExpression + ')\\b', 'i');
-        var checkBody = regexCheck.test(asyncResult.value);
+    // \b to perform a "whole words only" search using a regular expression in the form of \bword\b.
+    // i to perform case-insensitive search.
+    var regexCheck = new RegExp('\\b(' + wordExpression + ')\\b', 'i');
+    var checkBody = regexCheck.test(asyncResult.value);
 
-        if (checkBody) {
-            mailboxItem.notificationMessages.addAsync('NoSend', { type: 'errorMessage', message: 'Blocked words have been found in the body of this email. Please remove them.' });
-            // Block send.
-            asyncResult.asyncContext.completed({ allowEvent: false });
-        }
-
-        // Allow send.
-        asyncResult.asyncContext.completed({ allowEvent: true });
+    if (checkBody) {
+        mailboxItem.notificationMessages.addAsync('NoSend', { type: 'errorMessage', message: 'Blocked words have been found in the body of this email. Please remove them.' });
+        // Block send.
+        asyncResult.asyncContext.completed({ allowEvent: false });
     }
+
+    // Allow send.
+    asyncResult.asyncContext.completed({ allowEvent: true });
+}
 ```
 
 The following are the parameters for the **addAsync** method:
@@ -351,74 +353,71 @@ In addition to the **addAsync** method, the **NotificationMessages** object also
 The following code example shows you how to add a recipient to the CC line and verify that the message includes a subject on send. This example uses the on send feature to allow or disallow an email from sending.  
 
 ```js
-    // Invoke by Contoso Subject and CC Checker add-in before send is allowed.
-    // <param name="event">ItemSend event is automatically passed by on send code to the function specified in the manifest.</param>
-    function validateSubjectAndCC(event) {
-        shouldChangeSubjectOnSend(event);
-    }
+// Invoke by Contoso Subject and CC Checker add-in before send is allowed.
+// <param name="event">ItemSend event is automatically passed by on send code to the function specified in the manifest.</param>
+function validateSubjectAndCC(event) {
+    shouldChangeSubjectOnSend(event);
+}
 
-    // Determine whether the subject should be changed. If it is already changed, allow send. Otherwise change it.
-    // <param name="event">ItemSend event passed from the calling function.</param>
-    function shouldChangeSubjectOnSend(event) {
-        mailboxItem.subject.getAsync(
-            { asyncContext: event },
-            function (asyncResult) {
-                addCCOnSend(asyncResult.asyncContext);
-                //console.log(asyncResult.value);
-                // Match string.
-                var checkSubject = (new RegExp(/\[Checked\]/)).test(asyncResult.value)
-                // Add [Checked]: to subject line.
-                subject = '[Checked]: ' + asyncResult.value;
+// Determine whether the subject should be changed. If it is already changed, allow send. Otherwise change it.
+// <param name="event">ItemSend event passed from the calling function.</param>
+function shouldChangeSubjectOnSend(event) {
+    mailboxItem.subject.getAsync(
+        { asyncContext: event },
+        function (asyncResult) {
+            addCCOnSend(asyncResult.asyncContext);
+            //console.log(asyncResult.value);
+            // Match string.
+            var checkSubject = (new RegExp(/\[Checked\]/)).test(asyncResult.value)
+            // Add [Checked]: to subject line.
+            subject = '[Checked]: ' + asyncResult.value;
 
-                // Determine whether a string is blank, null, or undefined.
-                // If yes, block send and display information bar to notify sender to add a subject.
-                if (asyncResult.value === null || (/^\s*$/).test(asyncResult.value)) {
-                    mailboxItem.notificationMessages.addAsync('NoSend', { type: 'errorMessage', message: 'Please enter a subject for this email.' });
-                    asyncResult.asyncContext.completed({ allowEvent: false });
-                }
-                else {
-                    // If can't find a [Checked]: string match in subject, call subjectOnSendChange function.
-                    if (!checkSubject) {
-                        subjectOnSendChange(subject, asyncResult.asyncContext);
-                        //console.log(checkSubject);
-                    }
-                    else {
-                        // Allow send.
-                        asyncResult.asyncContext.completed({ allowEvent: true });
-                    }
-                }
-
+            // Determine whether a string is blank, null, or undefined.
+            // If yes, block send and display information bar to notify sender to add a subject.
+            if (asyncResult.value === null || (/^\s*$/).test(asyncResult.value)) {
+                mailboxItem.notificationMessages.addAsync('NoSend', { type: 'errorMessage', message: 'Please enter a subject for this email.' });
+                asyncResult.asyncContext.completed({ allowEvent: false });
             }
-          )
-    }
-
-    // Add a CC to the email. In this example, CC contoso@contoso.onmicrosoft.com
-    // <param name="event">ItemSend event passed from calling function</param>
-    function addCCOnSend(event) {
-        mailboxItem.cc.setAsync(['Contoso@contoso.onmicrosoft.com'], { asyncContext: event });
-    }
-
-    // Determine whether the subject should be changed. If it is already changed, allow send, otherwise change it.
-    // <param name="subject">Subject to set.</param>
-    // <param name="event">ItemSend event passed from the calling function.</param>
-    function subjectOnSendChange(subject, event) {
-        mailboxItem.subject.setAsync(
-            subject,
-            { asyncContext: event },
-            function (asyncResult) {
-                if (asyncResult.status == Office.AsyncResultStatus.Failed) {
-                    mailboxItem.notificationMessages.addAsync('NoSend', { type: 'errorMessage', message: 'Unable to set the subject.' });
-
-                    // Block send.
-                    asyncResult.asyncContext.completed({ allowEvent: false });
+            else {
+                // If can't find a [Checked]: string match in subject, call subjectOnSendChange function.
+                if (!checkSubject) {
+                    subjectOnSendChange(subject, asyncResult.asyncContext);
+                    //console.log(checkSubject);
                 }
                 else {
                     // Allow send.
                     asyncResult.asyncContext.completed({ allowEvent: true });
                 }
+            }
+        });
+}
 
-            });
-    }
+// Add a CC to the email. In this example, CC contoso@contoso.onmicrosoft.com
+// <param name="event">ItemSend event passed from calling function</param>
+function addCCOnSend(event) {
+    mailboxItem.cc.setAsync(['Contoso@contoso.onmicrosoft.com'], { asyncContext: event });
+}
+
+// Determine whether the subject should be changed. If it is already changed, allow send, otherwise change it.
+// <param name="subject">Subject to set.</param>
+// <param name="event">ItemSend event passed from the calling function.</param>
+function subjectOnSendChange(subject, event) {
+    mailboxItem.subject.setAsync(
+        subject,
+        { asyncContext: event },
+        function (asyncResult) {
+            if (asyncResult.status == Office.AsyncResultStatus.Failed) {
+                mailboxItem.notificationMessages.addAsync('NoSend', { type: 'errorMessage', message: 'Unable to set the subject.' });
+
+                // Block send.
+                asyncResult.asyncContext.completed({ allowEvent: false });
+            }
+            else {
+                // Allow send.
+                asyncResult.asyncContext.completed({ allowEvent: true });
+            }
+        });
+}
 ```
 
 To learn more about how to add a recipient to the CC line and verify that the email message includes a subject line on send, and to see the APIs you can use, see the [Outlook-Add-in-On-Send sample](https://github.com/OfficeDev/Outlook-Add-in-On-Send). The code is well commented.

--- a/docs/add-ins/outlook-on-send-addins.md
+++ b/docs/add-ins/outlook-on-send-addins.md
@@ -56,7 +56,7 @@ The following screenshot shows an information bar that notifies the sender that 
 
 The on send feature currently has the following limitations:
 
-- **AppSource** &ndash; You can't publish Outlook add-ins that use the on send feature to [APpSource](https://appsource.microsoft.com). Add-ins that use the on send event will fail AppSource validation.
+- **AppSource** &ndash; You can't publish Outlook add-ins that use the on send feature to [AppSource](https://appsource.microsoft.com). Add-ins that use the on send event will fail AppSource validation.
 - **Manifest** &ndash; Only one **ItemSend** event is supported per add-in. If you have two or more **ItemSend** events in a manifest, the manifest will fail validation.
 - **Performance** &ndash; Multiple roundtrips to the web server that hosts the add-in can affect the performance of the add-in. Consider the effects on performance when you create add-ins that require multiple email message-based operations.
 

--- a/docs/add-ins/outlook-on-send-addins.md
+++ b/docs/add-ins/outlook-on-send-addins.md
@@ -14,7 +14,7 @@ The on send feature for Outlook add-ins provides a way to handle email or block 
 - Add a specific recipient to the CC line.
 
 > [!NOTE]
-> The on send feature is currently supported for Outlook on the web (classic) in Office 365, Exchange 2016 on-premises (Cumulative Update 6 or later), and Exchange 2019 on-premises (Cumulative Update 1 or later). Add-ins that use the on send feature aren't allowed in the Office Store.
+> The on send feature is currently supported for Outlook on the web (classic) in Office 365, Exchange 2016 on-premises (Cumulative Update 6 or later), and Exchange 2019 on-premises (Cumulative Update 1 or later). Add-ins that use the on send feature aren't allowed in [AppSource](https://appsource.microsoft.com).
 
 The on send feature is triggered by events. Currently, the feature supports the **ItemSend** event type. Events in Outlook add-ins enable you to handle, check, or block user actions when something of interest occurs. For example, events provide ways to:
 
@@ -56,7 +56,7 @@ The following screenshot shows an information bar that notifies the sender that 
 
 The on send feature currently has the following limitations:
 
-- **Office Store** &ndash; You can't publish Outlook add-ins that use the on send feature to the Office Store. Add-ins that use the on send event will fail Office Store validation.
+- **AppSource** &ndash; You can't publish Outlook add-ins that use the on send feature to [APpSource](https://appsource.microsoft.com). Add-ins that use the on send event will fail AppSource validation.
 - **Manifest** &ndash; Only one **ItemSend** event is supported per add-in. If you have two or more **ItemSend** events in a manifest, the manifest will fail validation.
 - **Performance** &ndash; Multiple roundtrips to the web server that hosts the add-in can affect the performance of the add-in. Consider the effects on performance when you create add-ins that require multiple email message-based operations.
 

--- a/docs/add-ins/pinnable-taskpane.md
+++ b/docs/add-ins/pinnable-taskpane.md
@@ -25,7 +25,7 @@ The first step is to add pinning support, which is done in the add-in [manifest]
 The `SupportsPinning` element is defined in the VersionOverrides v1.1 schema, so you will need to include a [VersionOverrides](/office/dev/add-ins/reference/manifest/versionoverrides) element both for v1.0 and v1.1.
 
 > [!NOTE]
-> If you plan to [publish](/office/dev/add-ins/publish/publish) your Outlook add-in to the Office Store, when you use the **SupportsPinning** element, in order to pass [AppSource (Office Store) validation](/office/dev/store/validation-policies), your add-in content must not be static and it must clearly display data related to the message that is open or selected in the mailbox.
+> If you plan to [publish](/office/dev/add-ins/publish/publish) your Outlook add-in to [AppSource](https://appsource.microsoft.com), when you use the **SupportsPinning** element, in order to pass [AppSource validation](/office/dev/store/validation-policies), your add-in content must not be static and it must clearly display data related to the message that is open or selected in the mailbox.
 
 ```xml
 <!-- Task pane button -->

--- a/docs/add-ins/privacy-and-security.md
+++ b/docs/add-ins/privacy-and-security.md
@@ -12,7 +12,7 @@ End users, developers, and administrators can use the tiered permission levels o
 
 This article describes the possible permissions that Outlook add-ins can request, and examines the security model from the following perspectives:
 
-- **Office Store**: add-in integrity
+- **AppSource**: add-in integrity
     
 - **End-users**: privacy and performance concerns
     
@@ -47,9 +47,9 @@ The following figure shows the four levels of permissions and describes the capa
 ![4-tier permissions model for mail apps schema v1.1](images/add-in-permission-tiers.png)
 
 
-## Office Store: add-in integrity
+## AppSource: add-in integrity
 
-The Office Store hosts add-ins that can be installed by end users and administrators. The Office Store enforces the following measures to maintain the integrity of these Outlook add-ins:
+[AppSource](https://appsource.microsoft.com) hosts add-ins that can be installed by end users and administrators. AppSource enforces the following measures to maintain the integrity of these Outlook add-ins:
 
 - Requires the host server of an add-in to always use Secure Socket Layer (SSL) to communicate.
     
@@ -66,7 +66,7 @@ The security model addresses security, privacy, and performance concerns of end 
 
 - End user's messages that are protected by Outlook's Information Rights Management (IRM) do not interact with Outlook add-ins.
     
-- Before installing an add-in from the Office Store, end users can see the access and actions that the add-in can make on their data and must explicitly confirm to proceed. No Outlook add-in is automatically pushed onto a client computer without manual validation by the user or administrator.
+- Before installing an add-in from AppSource, end users can see the access and actions that the add-in can make on their data and must explicitly confirm to proceed. No Outlook add-in is automatically pushed onto a client computer without manual validation by the user or administrator.
     
 - Granting the **restricted** permission allows the Outlook add-in to have limited access on only the current item. Granting the **read item** permission allows the Outlook add-in to access personal identifiable information, such as sender and recipient names and email addresses, on only the current item,.
     
@@ -150,7 +150,7 @@ Developers should be aware of and plan for the following as well:
 
 - Developers cannot use ActiveX controls in add-ins because they are not supported.
     
-- Developers should do the following when submitting an Outlook add-in to the Office Store:
+- Developers should do the following when submitting an Outlook add-in to AppSource:
     
   - Produce an Extended Validation (EV) SSL certificate as a proof of identity.
     
@@ -165,7 +165,7 @@ Developers should be aware of and plan for the following as well:
 
 The security model provides the following rights and responsibilities to administrators:
 
-- Can prevent end users from installing any Outlook add-in, including add-ins on the Office Store.
+- Can prevent end users from installing any Outlook add-in, including add-ins from AppSource.
     
 - Can disable or enable any Outlook add-in on the Exchange Admin Center.
     

--- a/docs/add-ins/testing-and-tips.md
+++ b/docs/add-ins/testing-and-tips.md
@@ -72,11 +72,11 @@ Deciding what versions of the Outlook client to test depends on your development
 
 - If you are developing an add-in for private use, or only for members of your organization, then it is important to test the versions of Outlook that your company uses. Keep in mind that some users may use Outlook on the web, so testing your company's standard browser versions is also important.
 
-- If you are developing an add-in to list in the Office Store, you must test the required versions as specified in the [Office Store validation policies 4.12.1](/office/dev/store/validation-policies#4-apps-and-add-ins-behave-predictably). This includes:
+- If you are developing an add-in to list in [AppSource](https://appsource.microsoft.com), you must test the required versions as specified in the [AppSource validation policies 4.12.1](/office/dev/store/validation-policies#4-apps-and-add-ins-behave-predictably). This includes:
     - The latest version of Outlook on Windows and the version prior to the latest.
     - The latest version of Outlook on Mac.
     - The latest version of Outlook on iOS (if your add-in [supports mobile form factor](add-mobile-support.md)).
-    - The browser versions specified in Office Store validation policy 4.12.1.
+    - The browser versions specified in AppSource validation policy 4.12.1.
 
 > [!NOTE]
 > If your add-in does not support one of the above clients due to [requesting an API requirement set](apis.md) that the client does not support, that client would be removed from the list of required clients.

--- a/docs/add-ins/understanding-outlook-add-in-permissions.md
+++ b/docs/add-ins/understanding-outlook-add-in-permissions.md
@@ -10,7 +10,7 @@ localization_priority: Priority
 
 Outlook add-ins specify the required permission level in their manifest. The available levels are **Restricted**, **ReadItem**, **ReadWriteItem**, or **ReadWriteMailbox**. These levels of permissions are cumulative: **Restricted** is the lowest level, and each higher level includes the permissions of all the lower levels. **ReadWriteMailbox** includes all the supported permissions.
 
-You can see the permissions requested by a mail add-in before installing it from the Office Store. You can also see the required permissions of installed add-ins in the Exchange Admin Center.
+You can see the permissions requested by a mail add-in before installing it from [AppSource](https://appsource.microsoft.com). You can also see the required permissions of installed add-ins in the Exchange Admin Center.
 
 ## Restricted permission
 


### PR DESCRIPTION
Changes **Office Store** -> **AppSource** and **side-load** -> **sideload** throughout the docs, and also fixes code formatting issues in the **On Send** article. Note that I've intentionally *not* updated `ms.date` in any of these articles, since none of the changes are substantive.