### PR TITLE
[Add-ins] (Yo Office) Add note about spaces not being permitted in project name or folder path.

### DIFF
--- a/docs/add-ins/addin-tutorial.md
+++ b/docs/add-ins/addin-tutorial.md
@@ -95,6 +95,8 @@ The add-in that you'll create in this tutorial will read [gists](https://gist.gi
 
 ## Create an Outlook add-in project
 
+[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
+
 Use the Yeoman generator to create an Outlook add-in project.
 
 1. Run the following command from the command prompt and then answer the prompts as follows:
@@ -107,18 +109,16 @@ Use the Yeoman generator to create an Outlook add-in project.
 
     - **Choose a script type** - `Javascript`
 
-    - **What do you want to name your add-in?** - `Git the gist`
+    - **What do you want to name your add-in?** - `git-the-gist`
 
     - **Which Office client application would you like to support?** - `Outlook`
 
-    ![A screenshot of the prompts and answers for the Yeoman generator](images/addin-tutorial/yeoman-prompts-2.png)
-    
     After you complete the wizard, the generator will create the project and install supporting Node components.
 
 1. Navigate to the root directory of the project.
 
     ```command&nbsp;line
-    cd "Git the gist"
+    cd "git-the-gist"
     ```
 
 1. This add-in will use the following libraries:

--- a/docs/add-ins/quick-start.md
+++ b/docs/add-ins/quick-start.md
@@ -31,6 +31,8 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
 
 ### Create the add-in project
 
+[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
+
 1. Use the Yeoman generator to create an Outlook add-in project. Run the following command and then answer the prompts as follows:
 
     ```command&nbsp;line
@@ -41,18 +43,16 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
 
     - **Choose a script type** - `Javascript`
 
-    - **What do you want to name your add-in?** - `My Office Add-in`
+    - **What do you want to name your add-in?** - `my-office-add-in`
 
     - **Which Office client application would you like to support?** - `Outlook`
 
-    ![A screenshot of the prompts and answers for the Yeoman generator](images/yo-office-outlook.png)
-	
     After you complete the wizard, the generator will create the project and install supporting Node components.
 
 1. Navigate to the root folder of the web application project.
 
     ```command&nbsp;line
-    cd "My Office Add-in"
+    cd "my-office-add-in"
     ```
 
 ### Explore the project

--- a/docs/includes/note-yeoman-generator-bug-201908.md
+++ b/docs/includes/note-yeoman-generator-bug-201908.md
@@ -1,0 +1,2 @@
+> [!IMPORTANT]
+> Spaces are not currently permitted in the add-in project name or anywhere in the folder path where you create your add-in project. If your add-in's project name or folder path contains spaces, the local web server won't start when you run `npm start` or `npm run start:web`. This limitation is temporary and will be eliminated when the underlying [issue](https://github.com/OfficeDev/generator-office/issues/476) is resolved in the Yeoman generator for Office Add-ins.


### PR DESCRIPTION
This PR adds a note to call out a bug that's currently present in the Yeoman generator for Office Add-ins: OfficeDev/generator-office#476. It also removes the screenshots of Yo Office prompts (since screenshots show a currently-unpermitted value for project name). When the bug in Yo Office is fixed, we'll remove this note and restore the screenshot in each article that's updated by this PR.