### PR TITLE
[Admin] (metadata updates) Specify values for metadata attributes ms.topic and scenarios.

### DIFF
--- a/docs/add-ins/activation-rules.md
+++ b/docs/add-ins/activation-rules.md
@@ -1,7 +1,6 @@
 ---
 title: Outlook add-in activation rules
 description: Outlook activates some types of add-ins if the message or appointment that the user is reading or composing satisfies the activation rules of the add-in.
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/add-and-remove-attachments-to-an-item-in-a-compose-form.md
+++ b/docs/add-ins/add-and-remove-attachments-to-an-item-in-a-compose-form.md
@@ -1,7 +1,6 @@
 ---
 title: Add and remove attachments in an Outlook add-in
 description: You can use the addFileAttachmentAsync and addItemAttachmentAsync methods to attach a file and an Outlook item respectively to the item that the user is composing.
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/add-in-commands-for-outlook.md
+++ b/docs/add-ins/add-in-commands-for-outlook.md
@@ -1,7 +1,6 @@
 ---
 title: Outlook add-in commands
 description: Outlook add-in commands provide ways to initiate specific add-in actions from the ribbon by adding buttons or drop-down menus. 
-ms.topic: article
 ms.date: 08/01/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/add-in-requirements.md
+++ b/docs/add-ins/add-in-requirements.md
@@ -1,7 +1,6 @@
 ---
 title: Outlook add-in requirements
 description: For Outlook add-ins to load and function properly, there are a number of requirements for both the servers and the clients. 
-ms.topic: article
 ms.date: 08/01/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/add-mobile-support.md
+++ b/docs/add-ins/add-mobile-support.md
@@ -1,7 +1,6 @@
 ---
 title: Add mobile support to an Outlook add-in
 description: Adding support for Outlook Mobile requires updating the add-in manifest and possibly changing your code for mobile scenarios.
-ms.topic: article
 ms.date: 08/01/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/addin-tutorial.md
+++ b/docs/add-ins/addin-tutorial.md
@@ -2,6 +2,7 @@
 title: 'Tutorial: Build a message compose Outlook add-in'
 description: In this tutorial, you'll build an Outlook add-in that inserts GitHub gists into the body of a new message.
 ms.topic: tutorial
+scenarios: getting-started
 ms.date: 05/21/2019
 #Customer intent: As a developer, I want to create a message compose Outlook add-in.
 localization_priority: Priority

--- a/docs/add-ins/apis.md
+++ b/docs/add-ins/apis.md
@@ -1,7 +1,6 @@
 ---
 title: Outlook add-in APIs
 description: Learn how to reference the Outlook add-in APIs and declare permissions in your Outlook add-in.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/authenticate-a-user-with-an-identity-token.md
+++ b/docs/add-ins/authenticate-a-user-with-an-identity-token.md
@@ -1,7 +1,6 @@
 ---
 title: Authenticate a user with an identity token in an add-in
 description: Learn about using the identity token provided by an Outlook add-in to implement SSO with your service.
-ms.topic: article
 ms.date: 05/31/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/authenticate-a-user-with-an-sso-token.md
+++ b/docs/add-ins/authenticate-a-user-with-an-sso-token.md
@@ -1,7 +1,6 @@
 ---
 title: Authenticate a user with a single-sign-on token
 description: Learn about using the single-sign-on token provided by an Outlook add-in to implement SSO with your service.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/authentication.md
+++ b/docs/add-ins/authentication.md
@@ -1,7 +1,6 @@
 ---
 title: Authentication options in Outlook add-ins
 description: Outlook add-ins provide a number of different methods to authenticate, depending on your specific scenario.
-ms.topic: article
 ms.date: 05/31/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/categories.md
+++ b/docs/add-ins/categories.md
@@ -1,7 +1,6 @@
 ---
 title: Get and set categories
 description: How to manage categories on mailbox and item
-ms.topic: article
 ms.date: 08/26/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/compare-outlook-add-in-support-in-outlook-for-mac.md
+++ b/docs/add-ins/compare-outlook-add-in-support-in-outlook-for-mac.md
@@ -1,7 +1,6 @@
 ---
 title: Compare Outlook add-in support in Outlook on Mac
 description: Learn how add-in support in Outlook on Mac compares with other Outlook hosts.
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/compose-scenario.md
+++ b/docs/add-ins/compose-scenario.md
@@ -1,7 +1,6 @@
 ---
 title: Create Outlook add-ins for compose forms
 description: Learn about scenarios and capabilities of Outlook add-ins for compose forms.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/contextual-outlook-add-ins.md
+++ b/docs/add-ins/contextual-outlook-add-ins.md
@@ -1,7 +1,6 @@
 ---
 title: Contextual Outlook add-ins
 description: Initiate tasks related to a message without leaving the message itself to result in an easier and richer user experience.
-ms.topic: article
 ms.date: 08/23/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/delegate-access.md
+++ b/docs/add-ins/delegate-access.md
@@ -1,7 +1,6 @@
 ---
 title: Enable delegate access scenarios in an Outlook add-in
 description: Briefly describes delegate access and discusses how to configure add-in support.
-ms.topic: article
 ms.date: 08/26/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/extension-module-outlook-add-ins.md
+++ b/docs/add-ins/extension-module-outlook-add-ins.md
@@ -1,7 +1,6 @@
 ---
 title: Module extension Outlook add-ins
 description: Create applications that run inside Outlook to make it easy for your users to access business information and productivity tools without ever leaving Outlook.
-ms.topic: article
 ms.date: 06/04/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/extract-entity-strings-from-an-item.md
+++ b/docs/add-ins/extract-entity-strings-from-an-item.md
@@ -1,7 +1,6 @@
 ---
 title: Extract entity strings from an Outlook item
 description: Learn how to extract entity strings from an Outlook item in an Outlook add-in.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/get-and-set-item-data-in-a-compose-form.md
+++ b/docs/add-ins/get-and-set-item-data-in-a-compose-form.md
@@ -1,7 +1,6 @@
 ---
 title: Get and set item data in a compose form in Outlook
 description: Get or set various properties of an item in an Outlook add-in in a compose scenario, including its recipients, subject, body, and appointment location and time.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/get-and-set-recurrence.md
+++ b/docs/add-ins/get-and-set-recurrence.md
@@ -1,7 +1,6 @@
 ---
 title: Get and set recurrence in an Outlook add-in
 description: This topic shows you how to use the Office JavaScript API to get and set various recurrence properties of an item in an Outlook add-in.
-ms.topic: article
 ms.date: 12/12/2018
 localization_priority: Normal
 ---

--- a/docs/add-ins/get-attachments-of-an-outlook-item.md
+++ b/docs/add-ins/get-attachments-of-an-outlook-item.md
@@ -1,7 +1,6 @@
 ---
 title: Get attachments in an Outlook add-in
 description: Your add-in can use the attachments API to send information about the attachments to a remote service.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/get-or-set-the-location-of-an-appointment.md
+++ b/docs/add-ins/get-or-set-the-location-of-an-appointment.md
@@ -1,7 +1,6 @@
 ---
 title: Get or set the location of an appointment in an add-in
 description: Learn how to get or set the location of an appointment in an Outlook add-in.
-ms.topic: article
 ms.date: 08/28/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/get-or-set-the-subject.md
+++ b/docs/add-ins/get-or-set-the-subject.md
@@ -1,7 +1,6 @@
 ---
 title: Get or set the subject in an Outlook add-in
 description: Learn how to get or set the subject of a message or appointment in an Outlook add-in.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/get-or-set-the-time-of-an-appointment.md
+++ b/docs/add-ins/get-or-set-the-time-of-an-appointment.md
@@ -1,7 +1,6 @@
 ---
 title: Get or set appointment time in an Outlook add-in
 description: Learn how to get or set the start and end time of an appointment in an Outlook add-in.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/get-set-or-add-recipients.md
+++ b/docs/add-ins/get-set-or-add-recipients.md
@@ -1,7 +1,6 @@
 ---
 title: Get or modify recipients in an Outlook add-in
 description: Learn how to get, set, or add recipients of a message or appointment in an Outlook add-in.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/implement-sso-in-outlook-add-in.md
+++ b/docs/add-ins/implement-sso-in-outlook-add-in.md
@@ -1,7 +1,6 @@
 ---
 title: Scenario - Implement single sign-on to your service
 description: Learn about using the single-sign-on token and Exchange identity token provided by an Outlook add-in to implement SSO with your service.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/index.md
+++ b/docs/add-ins/index.md
@@ -1,8 +1,9 @@
 ---
 title: Outlook add-ins overview
 description: Outlook add-ins are integrations built by third parties into Outlook by using our web-based platform. 
-ms.topic: article
 ms.date: 06/24/2019
+ms.topic: overview
+scenarios: getting-started
 localization_priority: Priority
 ---
 

--- a/docs/add-ins/insert-data-in-the-body.md
+++ b/docs/add-ins/insert-data-in-the-body.md
@@ -1,7 +1,6 @@
 ---
 title: Insert data in the body in an Outlook add-in
 description: Learn how to insert data into the body of a message or appointment in an Outlook add-in.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/inside-the-identity-token.md
+++ b/docs/add-ins/inside-the-identity-token.md
@@ -1,7 +1,6 @@
 ---
 title: Inside the Exchange identity token in an Outlook add-in
 description: Learn about the contents of an Exchange user identity token generated from an Outlook add-in.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/item-data.md
+++ b/docs/add-ins/item-data.md
@@ -1,7 +1,6 @@
 ---
 title: Get or set item data in an Outlook add-in
 description: Depending on whether an add-in is activated in a read or compose form, the properties that are available to the add-in on an item differ.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/limits-for-activation-and-javascript-api-for-outlook-add-ins.md
+++ b/docs/add-ins/limits-for-activation-and-javascript-api-for-outlook-add-ins.md
@@ -1,7 +1,6 @@
 ---
 title: Limits for activation and API usage in Outlook add-ins
 description: Be aware of certain activation and API usage guidelines, and implement your add-ins to stay within these limits.
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/manifests.md
+++ b/docs/add-ins/manifests.md
@@ -1,7 +1,6 @@
 ---
 title: Outlook add-in manifests
 description: The manifest describes how an Outlook add-in integrates across Outlook clients; includes an example.
-ms.topic: article
 ms.date: 05/29/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/match-strings-in-an-item-as-well-known-entities.md
+++ b/docs/add-ins/match-strings-in-an-item-as-well-known-entities.md
@@ -1,7 +1,6 @@
 ---
 title: Match strings as well-known entities in an Outlook add-in
 description: Using the JavaScript API for Office, you can get strings that match specific well-known entities for further processing.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/metadata-for-an-outlook-add-in.md
+++ b/docs/add-ins/metadata-for-an-outlook-add-in.md
@@ -1,7 +1,6 @@
 ---
 title: Get and set metadata in an Outlook add-in
 description: Manage custom data in your Outlook add-in by using either roaming settings or custom properties.
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/outlook-addin-design.md
+++ b/docs/add-ins/outlook-addin-design.md
@@ -1,7 +1,6 @@
 ---
 title: Outlook add-in design
 description: Guidelines to help you design and build a compelling add-in, which brings the best of your app right into Outlook on Windows, Web, iOS, Mac, and Android.
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/outlook-mobile-addins.md
+++ b/docs/add-ins/outlook-mobile-addins.md
@@ -1,7 +1,6 @@
 ---
 title: Outlook add-ins for Outlook Mobile
 description: Outlook mobile add-ins are supported on all Office 365 Commercial accounts, Outlook.com accounts, and support is coming soon to gmail accounts.
-ms.topic: article
 ms.date: 08/01/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/outlook-on-send-addins.md
+++ b/docs/add-ins/outlook-on-send-addins.md
@@ -1,7 +1,6 @@
 ---
 title: On send feature for Outlook add-ins
 description: Provides a way to handle email or block email users from certain actions, and allows an add-in to set certain items on send.
-ms.topic: article
 ms.date: 08/01/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/pinnable-taskpane.md
+++ b/docs/add-ins/pinnable-taskpane.md
@@ -1,7 +1,6 @@
 ---
 title: Implement a pinnable task pane in an Outlook add-in
 description: The task pane UX shape for add-in commands opens a vertical task pane to the right of an open message or meeting request, allowing the add-in to provide UI for more detailed interactions.
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/privacy-and-security.md
+++ b/docs/add-ins/privacy-and-security.md
@@ -1,7 +1,6 @@
 ---
 title: Privacy, permissions, and security for Outlook add-ins
 description: Learn how to manage privacy, permissions, and security in an Outlook add-in.
-ms.topic: article
 ms.date: 05/10/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/quick-start.md
+++ b/docs/add-ins/quick-start.md
@@ -2,6 +2,7 @@
 title: Build your first Outlook add-in
 description: Learn how to build a simple Outlook task pane add-in by using the Office JS API.
 ms.topic: quickstart
+scenarios: getting-started
 ms.date: 07/17/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/read-scenario.md
+++ b/docs/add-ins/read-scenario.md
@@ -1,7 +1,6 @@
 ---
 title: Create Outlook add-ins for read forms
 description: Read add-ins are Outlook add-ins that are activated in the Reading Pane or read inspector in Outlook.
-ms.topic: article
 ms.date: 04/12/2018
 localization_priority: Normal
 ---

--- a/docs/add-ins/sideload-outlook-add-ins-for-testing.md
+++ b/docs/add-ins/sideload-outlook-add-ins-for-testing.md
@@ -1,7 +1,6 @@
 ---
 title: Sideload Outlook add-ins for testing
 description: Use sideloading to install an Outlook add-in for testing without having to first put it in an add-in catalog.
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/testing-and-tips.md
+++ b/docs/add-ins/testing-and-tips.md
@@ -1,7 +1,6 @@
 ---
 title: Deploy and install Outlook add-ins for testing
 description: Create a manifest file, deploy the add-in UI file to a web server, install the add-in in your mailbox, and then test the add-in.
-ms.topic: article
 ms.date: 08/01/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/tips-for-handling-date-values-in-outlook-add-ins.md
+++ b/docs/add-ins/tips-for-handling-date-values-in-outlook-add-ins.md
@@ -1,7 +1,6 @@
 ---
 title: Handling date values in Outlook add-ins
 description: The JavaScript API for Office uses the JavaScript Date object for most of the storage and retrieval of dates and times. 
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/troubleshoot-outlook-add-in-activation.md
+++ b/docs/add-ins/troubleshoot-outlook-add-in-activation.md
@@ -1,7 +1,6 @@
 ---
 title: Troubleshoot Outlook contextual add-in activation
 description: If your add-in doesn't activate as you expect, you should look into the following areas for possible reasons.
-ms.topic: article
 ms.date: 06/24/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/understanding-outlook-add-in-permissions.md
+++ b/docs/add-ins/understanding-outlook-add-in-permissions.md
@@ -1,7 +1,6 @@
 ---
 title: Understanding Outlook add-in permissions
 description: Outlook add-ins specify the required permission level in their manifest, which include Restricted, ReadItem, ReadWriteItem, or ReadWriteMailbox. 
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/use-regular-expressions-to-show-an-outlook-add-in.md
+++ b/docs/add-ins/use-regular-expressions-to-show-an-outlook-add-in.md
@@ -1,7 +1,6 @@
 ---
 title: Use regular expression activation rules to show an add-in
 description: Learn how to use regular expression activation rules for Outlook contextual add-ins.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/use-rest-api.md
+++ b/docs/add-ins/use-rest-api.md
@@ -1,7 +1,6 @@
 ---
 title: Use the Outlook REST APIs from an Outlook add-in
 description: Learn how to use the Outlook REST APIs from an Outlook add-in to get an access token.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/add-ins/validate-an-identity-token.md
+++ b/docs/add-ins/validate-an-identity-token.md
@@ -1,7 +1,6 @@
 ---
 title: Validate an Outlook add-in identity token
 description: Your Outlook add-in can send you an Exchange user identity token, but before you trust the request you must validate the token to ensure that it came from the Exchange server that you expect.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Normal
 ---

--- a/docs/add-ins/web-services.md
+++ b/docs/add-ins/web-services.md
@@ -1,7 +1,6 @@
 ---
 title: Use Exchange Web Services (EWS) from an Outlook add-in
 description: Provides an example that shows how an Outlook add-in can request information from Exchange Web Services.
-ms.topic: article
 ms.date: 04/15/2019
 localization_priority: Priority
 ---

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -55,6 +55,9 @@
       },
       "ms.technology": {
         "add-ins/*.md": "add-ins"
+      },
+      "ms.topic": {
+        "add-ins/*.md": "conceptual"
       }
     },
     "template": [],


### PR DESCRIPTION
This PR specifies `ms.topic` metadata value = `conceptual` for all files in the /add-ins folder by using a setting in **docfx.json** (and removes that individual metadata attribute from nearly all files in the /add-ins folder). It also sets the `ms.topic` and `scenarios` metadata attributes at the individual file level for the Add-ins overview article, the Add-ins quick start, and the Add-ins tutorial (thereby overriding any global or folder level attribute settings from docfx.json that would otherwise apply to these articles).