### PR TITLE
[Add-ins] (Yo Office) Remove note about spaces not being permitted in project name or folder path.

### DIFF
--- a/docs/add-ins/addin-tutorial.md
+++ b/docs/add-ins/addin-tutorial.md
@@ -3,7 +3,7 @@ title: 'Tutorial: Build a message compose Outlook add-in'
 description: In this tutorial, you'll build an Outlook add-in that inserts GitHub gists into the body of a new message.
 ms.topic: tutorial
 scenarios: getting-started
-ms.date: 05/21/2019
+ms.date: 09/06/2019
 #Customer intent: As a developer, I want to create a message compose Outlook add-in.
 localization_priority: Priority
 ---
@@ -96,8 +96,6 @@ The add-in that you'll create in this tutorial will read [gists](https://gist.gi
 
 ## Create an Outlook add-in project
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 Use the Yeoman generator to create an Outlook add-in project.
 
 1. Run the following command from the command prompt and then answer the prompts as follows:
@@ -110,16 +108,18 @@ Use the Yeoman generator to create an Outlook add-in project.
 
     - **Choose a script type** - `Javascript`
 
-    - **What do you want to name your add-in?** - `git-the-gist`
+    - **What do you want to name your add-in?** - `Git the gist`
 
     - **Which Office client application would you like to support?** - `Outlook`
 
+    ![A screenshot of the prompts and answers for the Yeoman generator](images/addin-tutorial/yeoman-prompts-2.png)
+    
     After you complete the wizard, the generator will create the project and install supporting Node components.
 
 1. Navigate to the root directory of the project.
 
     ```command&nbsp;line
-    cd "git-the-gist"
+    cd "Git the gist"
     ```
 
 1. This add-in will use the following libraries:

--- a/docs/add-ins/quick-start.md
+++ b/docs/add-ins/quick-start.md
@@ -3,7 +3,7 @@ title: Build your first Outlook add-in
 description: Learn how to build a simple Outlook task pane add-in by using the Office JS API.
 ms.topic: quickstart
 scenarios: getting-started
-ms.date: 07/17/2019
+ms.date: 09/06/2019
 localization_priority: Priority
 ---
 
@@ -32,8 +32,6 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
 
 ### Create the add-in project
 
-[!include[note about Yeoman generator bug](../includes/note-yeoman-generator-bug-201908.md)]
-
 1. Use the Yeoman generator to create an Outlook add-in project. Run the following command and then answer the prompts as follows:
 
     ```command&nbsp;line
@@ -44,16 +42,18 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
 
     - **Choose a script type** - `Javascript`
 
-    - **What do you want to name your add-in?** - `my-office-add-in`
+    - **What do you want to name your add-in?** - `My Office Add-in`
 
     - **Which Office client application would you like to support?** - `Outlook`
 
+    ![A screenshot of the prompts and answers for the Yeoman generator](images/yo-office-outlook.png)
+    
     After you complete the wizard, the generator will create the project and install supporting Node components.
 
 1. Navigate to the root folder of the web application project.
 
     ```command&nbsp;line
-    cd "my-office-add-in"
+    cd "My Office Add-in"
     ```
 
 ### Explore the project

--- a/docs/includes/note-yeoman-generator-bug-201908.md
+++ b/docs/includes/note-yeoman-generator-bug-201908.md
@@ -1,2 +1,0 @@
-> [!IMPORTANT]
-> Spaces are not currently permitted in the add-in project name or anywhere in the folder path where you create your add-in project. If your add-in's project name or folder path contains spaces, the local web server won't start when you run `npm start` or `npm run start:web`. This limitation is temporary and will be eliminated when the underlying [issue](https://github.com/OfficeDev/generator-office/issues/476) is resolved in the Yeoman generator for Office Add-ins.


### PR DESCRIPTION
This PR reverts changes made in PR #670 (now that the issue with spaces not being allowed in project names / folder paths has been resolved).