### PR TITLE
[Add-ins] (Yo Office guidance) Add notes about telemetry prompts and next steps guidance.

### DIFF
--- a/docs/add-ins/addin-tutorial.md
+++ b/docs/add-ins/addin-tutorial.md
@@ -98,11 +98,16 @@ The add-in that you'll create in this tutorial will read [gists](https://gist.gi
 
 Use the Yeoman generator to create an Outlook add-in project.
 
-1. Run the following command from the command prompt and then answer the prompts as follows:
+1. Run the following command to create an add-in project using the Yeoman generator: 
 
     ```command&nbsp;line
     yo office
     ```
+
+    > [!NOTE]
+    > When you run the `yo office` command, you may receive prompts about the data collection policies of Yeoman and the Office Add-in CLI tools. Use the information that's provided to respond to the prompts as you see fit. If you choose **Exit** in response to the second prompt, you'll need to run the `yo office` command again when you're ready to create your add-in project.
+
+    When prompted, provide the following information to create your add-in project:
 
     - **Choose a project type** - `Office Add-in Task Pane project`
 
@@ -115,6 +120,9 @@ Use the Yeoman generator to create an Outlook add-in project.
     ![A screenshot of the prompts and answers for the Yeoman generator](images/addin-tutorial/yeoman-prompts-2.png)
     
     After you complete the wizard, the generator will create the project and install supporting Node components.
+
+    > [!TIP]
+    > You can ignore the *next steps* guidance that the Yeoman generator provides after the add-in project's been created. The step-by-step instructions within this article provide all of the guidance you'll need to complete this tutorial.
 
 1. Navigate to the root directory of the project.
 

--- a/docs/add-ins/addin-tutorial.md
+++ b/docs/add-ins/addin-tutorial.md
@@ -96,16 +96,7 @@ The add-in that you'll create in this tutorial will read [gists](https://gist.gi
 
 ## Create an Outlook add-in project
 
-1. Run the following command to create an add-in project using the Yeoman generator: 
-
-    ```command&nbsp;line
-    yo office
-    ```
-
-    > [!NOTE]
-    > When you run the `yo office` command, you may receive prompts about the data collection policies of Yeoman and the Office Add-in CLI tools. Use the information that's provided to respond to the prompts as you see fit. If you choose **Exit** in response to the second prompt, you'll need to run the `yo office` command again when you're ready to create your add-in project.
-
-    When prompted, provide the following information to create your add-in project:
+1. [!include[Yeoman generator create project guidance](../includes/yo-office-command-guidance.md)]
 
     - **Choose a project type** - `Office Add-in Task Pane project`
 
@@ -119,8 +110,7 @@ The add-in that you'll create in this tutorial will read [gists](https://gist.gi
     
     After you complete the wizard, the generator will create the project and install supporting Node components.
 
-    > [!TIP]
-    > You can ignore the *next steps* guidance that the Yeoman generator provides after the add-in project's been created. The step-by-step instructions within this article provide all of the guidance you'll need to complete this tutorial.
+    [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 1. Navigate to the root directory of the project.
 

--- a/docs/add-ins/addin-tutorial.md
+++ b/docs/add-ins/addin-tutorial.md
@@ -96,8 +96,6 @@ The add-in that you'll create in this tutorial will read [gists](https://gist.gi
 
 ## Create an Outlook add-in project
 
-Use the Yeoman generator to create an Outlook add-in project.
-
 1. Run the following command to create an add-in project using the Yeoman generator: 
 
     ```command&nbsp;line

--- a/docs/add-ins/quick-start.md
+++ b/docs/add-ins/quick-start.md
@@ -32,16 +32,7 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
 
 ### Create the add-in project
 
-1. Run the following command to create an add-in project using the Yeoman generator: 
-
-    ```command&nbsp;line
-    yo office
-    ```
-
-    > [!NOTE]
-    > When you run the `yo office` command, you may receive prompts about the data collection policies of Yeoman and the Office Add-in CLI tools. Use the information that's provided to respond to the prompts as you see fit. If you choose **Exit** in response to the second prompt, you'll need to run the `yo office` command again when you're ready to create your add-in project.
-
-    When prompted, provide the following information to create your add-in project:
+1. [!include[Yeoman generator create project guidance](../includes/yo-office-command-guidance.md)]
 
     - **Choose a project type** - `Office Add-in Task Pane project`
 
@@ -55,8 +46,7 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
     
     After you complete the wizard, the generator will create the project and install supporting Node components.
 
-    > [!TIP]
-    > You can ignore the *next steps* guidance that the Yeoman generator provides after the add-in project's been created. The step-by-step instructions within this article provide all of the guidance you'll need to complete this tutorial.
+    [!include[Yeoman generator next steps](../includes/yo-office-next-steps.md)]
 
 1. Navigate to the root folder of the web application project.
 

--- a/docs/add-ins/quick-start.md
+++ b/docs/add-ins/quick-start.md
@@ -32,11 +32,16 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
 
 ### Create the add-in project
 
-1. Use the Yeoman generator to create an Outlook add-in project. Run the following command and then answer the prompts as follows:
+1. Run the following command to create an add-in project using the Yeoman generator: 
 
     ```command&nbsp;line
     yo office
     ```
+
+    > [!NOTE]
+    > When you run the `yo office` command, you may receive prompts about the data collection policies of Yeoman and the Office Add-in CLI tools. Use the information that's provided to respond to the prompts as you see fit. If you choose **Exit** in response to the second prompt, you'll need to run the `yo office` command again when you're ready to create your add-in project.
+
+    When prompted, provide the following information to create your add-in project:
 
     - **Choose a project type** - `Office Add-in Task Pane project`
 
@@ -49,6 +54,9 @@ You can create an Office Add-in by using the [Yeoman generator for Office Add-in
     ![A screenshot of the prompts and answers for the Yeoman generator](images/yo-office-outlook.png)
     
     After you complete the wizard, the generator will create the project and install supporting Node components.
+
+    > [!TIP]
+    > You can ignore the *next steps* guidance that the Yeoman generator provides after the add-in project's been created. The step-by-step instructions within this article provide all of the guidance you'll need to complete this tutorial.
 
 1. Navigate to the root folder of the web application project.
 

--- a/docs/includes/yo-office-command-guidance.md
+++ b/docs/includes/yo-office-command-guidance.md
@@ -5,6 +5,6 @@ yo office
 ```
 
 > [!NOTE]
-> When you run the `yo office` command, you may receive prompts about the data collection policies of Yeoman and the Office Add-in CLI tools. Use the information that's provided to respond to the prompts as you see fit. If you choose **Exit** in response to the second prompt, you'll need to run the `yo office` command again when you're ready to create your add-in project.
+> When you run the `yo office` command, you may receive prompts about the data collection policies of Yeoman and the Office Add-in CLI tools. Use the information that's provided to respond to the prompts as you see fit.
 
 When prompted, provide the following information to create your add-in project:

--- a/docs/includes/yo-office-command-guidance.md
+++ b/docs/includes/yo-office-command-guidance.md
@@ -1,0 +1,10 @@
+Run the following command to create an add-in project using the Yeoman generator: 
+
+```command&nbsp;line
+yo office
+```
+
+> [!NOTE]
+> When you run the `yo office` command, you may receive prompts about the data collection policies of Yeoman and the Office Add-in CLI tools. Use the information that's provided to respond to the prompts as you see fit. If you choose **Exit** in response to the second prompt, you'll need to run the `yo office` command again when you're ready to create your add-in project.
+
+When prompted, provide the following information to create your add-in project:

--- a/docs/includes/yo-office-next-steps.md
+++ b/docs/includes/yo-office-next-steps.md
@@ -1,0 +1,2 @@
+> [!TIP]
+> You can ignore the *next steps* guidance that the Yeoman generator provides after the add-in project's been created. The step-by-step instructions within this article provide all of the guidance you'll need to complete this tutorial.


### PR DESCRIPTION
This PR adds a couple of new notes to each article that contains instructions for using Yo Office -- a note about telemetry prompts, and a tip about ignoring 'next steps'. (Corresponding changes have been made in OfficeDev/office-js-docs-pr as part of this PR: https://github.com/OfficeDev/office-js-docs-pr/pull/1304.)