### PR TITLE
Update security-requirements.md

### DIFF
--- a/docs/actionable-messages/security-requirements.md
+++ b/docs/actionable-messages/security-requirements.md
@@ -135,7 +135,7 @@ Please refer to the Microsoft code samples provided below, which show how to do 
 
 ### Action-Authorization header
 
-The use of `Authorization` header by Actionable messages may interfere with existing authentication/authorization mechanism for the target endpoint. In this case, developers can set the `Authorization` header to `null` or an empty string in the `headers` property of an `Action.Http` action. Actionable messages will then send the same bearer token via `Action-Authorization` header instead of using `Authorization` header.
+The use of `Authorization` header by Actionable messages may interfere with existing authentication/authorization mechanism for the target endpoint. In this case, developers can set the `Authorization` header to an empty string in the `headers` property of an `Action.Http` action. Actionable messages will then send the same bearer token via `Action-Authorization` header instead of using `Authorization` header.
 
 > [!TIP]
 > The Azure Logic App service returns `HTTP 401 Unauthorized` if the `Authorization` header contains the bearer token set by actionable messages.


### PR DESCRIPTION
Remove: "null" or
We encountered a persistent 401 error while implementing the code (given below) for a customer using Okta for authentication. Despite verifying the compatibility of the Outlook version with actionable messages and raising a support ticket with Microsoft, their suggestion to set it to an empty string. "null" seems confusing. To provide more clarity and convenience for developers, it would be helpful to include a valid example for "null" that can be easily copied and pasted into the code, or simply remove it. Thank you for your assistance! 

```json
"actions": [
    {
        "type": "Action.Http",
        "id": "83667e35-2ef1-ab00-eb3a-9d9fa7ff0977",
        "title": "Submit",
        "url": "#ActionHttp#",
        "method": "POST",
        "body": "{\n  \"response\": \"Reject\",\n  \"comment\": \"{{commentReject.value}}\"\n}",
        "headers": [
            {
                "name": "Authorization"
            },
            {
                "name": "Content-type",
                "value": "application/json"
            }
        ]
    }
]
```