### PR TITLE
Update add-in invocation for unified manifest

### DIFF
--- a/docs/actionable-messages/invoke-add-in.md
+++ b/docs/actionable-messages/invoke-add-in.md
@@ -63,8 +63,6 @@ The following shows the JSON for a extenions object that includes a control that
   -- other properties omitted --
 
   "extensions": [
-    -- other properties omitted --
-
     {
       "runtimes": [
         {
@@ -80,32 +78,28 @@ The following shows the JSON for a extenions object that includes a control that
         }
       ],
       "ribbons": [
-        -- other properties omitted --
-
         {
           "contexts": ["mailRead"],
           "tabs" [
-            -- other properties omitted --
-
-            "groups": [
-              -- other properties omitted --
-              
-              {
-                "controls" [
-                  {
-                    "id": "msgReadOpenPaneButton",
-                    "type": "button",
-                    "label": "Show Task Pane",
-                    "icons": [ -- icons markup omitted -- ],
-                    "supertip": {
-                        "title": "Show Contoso Task Pane",
-                        "description": "Opens the Contoso task pane."
-                    },
-                    "actionId": "ShowTaskPane"
-                  }
-                ]
-              }
-            ]
+            {
+              "groups": [            
+                {
+                  "controls" [
+                    {
+                      "id": "msgReadOpenPaneButton",
+                      "type": "button",
+                      "label": "Show Task Pane",
+                      "icons": [ -- icons markup omitted -- ],
+                      "supertip": {
+                          "title": "Show Contoso Task Pane",
+                          "description": "Opens the Contoso task pane."
+                      },
+                      "actionId": "ShowTaskPane"
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]

--- a/docs/actionable-messages/invoke-add-in.md
+++ b/docs/actionable-messages/invoke-add-in.md
@@ -84,6 +84,8 @@ The following shows the JSON for a extenions object that includes a control that
             {
               "groups": [            
                 {
+                  -- other properties omitted --
+                  
                   "controls" [
                     {
                       "id": "msgReadOpenPaneButton",

--- a/docs/actionable-messages/invoke-add-in.md
+++ b/docs/actionable-messages/invoke-add-in.md
@@ -56,7 +56,7 @@ Next, you'll need the [`"control.id"`](/microsoft-365/extensibility/schema/exten
 - Have its `"type"` property set to `button`.
 - Contain an `"actionId"` set to the same value as a the [`"actions.id"`](/microsoft-365/extensibility/schema/extension-runtimes-actions-item#id) of an action object defined in the [`"extensions.runtimes"`](/microsoft-365/extensibility/schema/extension-runtimes-array) array.
 
-The following shows the JSON for a extenions object that includes a control that opens a task pane.
+The following shows the JSON for an extensions object that includes a control that opens a task pane.
 
 ```json
 {

--- a/docs/actionable-messages/invoke-add-in.md
+++ b/docs/actionable-messages/invoke-add-in.md
@@ -31,7 +31,94 @@ The following example shows the prompt users see if the add-in is not installed.
 
 Actionable messages invoke add-ins by specifying an [Action.InvokeAddInCommand action](adaptive-card.md#actioninvokeaddincommand) in the message. This action specifies the add-in to invoke, along with the identifier of the add-in button that opens the appropriate task pane.
 
-The required information is found in the [add-in's manifest](/office/dev/add-ins/outlook/manifests). First, you'll need the add-in's identifier, which is specified in the [Id element](/office/dev/add-ins/reference/manifest/id).
+The required information is found in the [add-in's manifest](/office/dev/add-ins/develop/add-in-manifests). Open the tab for the type of manifest that the add-in uses.
+
+# [Unified manifest for Microsoft 365](#tab/jsonmanifest)
+
+First, you'll need the add-in's identifier, which is specified in the [`"id"`](/microsoft-365/extensibility/schema/root#id) property.
+
+```json
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.24/MicrosoftTeams.schema.json",
+  "id": "527104a1-f1a5-475a-9199-7a968161c870",
+  "version": "1.0.0",
+  "manifestVersion": "1.24",
+
+  -- other properties omitted --
+}
+```
+
+For this add-in, the add-in identifier is `527104a1-f1a5-475a-9199-7a968161c870`.
+
+Next, you'll need the [`"control.id"`](/microsoft-365/extensibility/schema/extension-common-custom-group-controls-item#id) value of the control object that defines the add-in button that opens the appropriate task pane. Keep in mind that the control object MUST:
+
+- Be defined inside a ribbon object that includes `mailRead` in its [`"ribbons.contexts"`](/microsoft-365/extensibility/schema/extension-ribbons-array#contexts) array.
+- Have its `"type"` property set to `button`.
+- Contain an `"actionId"` set to the same value as a the [`"actions.id"`](/microsoft-365/extensibility/schema/extension-runtimes-actions-item#id) of an action object defined in the [`"extensions.runtimes"`](/microsoft-365/extensibility/schema/extension-runtimes-array) array.
+
+The following shows the JSON for a extenions object that includes a control that opens a task pane.
+
+```json
+{
+  -- other properties omitted --
+
+  "extensions": [
+    -- other properties omitted --
+
+    {
+      "runtimes": [
+        {
+          -- other properties omitted --
+
+          "actions": [
+            {
+              -- other properties omitted --
+
+              "id": "ShowTaskpane"
+            }
+          ]
+        }
+      ],
+      "ribbons": [
+        -- other properties omitted --
+
+        {
+          "contexts": ["mailRead"],
+          "tabs" [
+            -- other properties omitted --
+
+            "groups": [
+              -- other properties omitted --
+              
+              {
+                "controls" [
+                  {
+                    "id": "msgReadOpenPaneButton",
+                    "type": "button",
+                    "label": "Show Task Pane",
+                    "icons": [ -- icons markup omitted -- ],
+                    "supertip": {
+                        "title": "Show Contoso Task Pane",
+                        "description": "Opens the Contoso task pane."
+                    },
+                    "actionId": "ShowTaskPane"
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+For this add-in button, the ID is `msgReadOpenPaneButton`.
+
+# [Add-in only manifest](#tab/xmlmanifest)
+
+First, you'll need the add-in's identifier, which is specified in the [Id element](/office/dev/add-ins/reference/manifest/id).
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -81,6 +168,8 @@ Next, you'll need the `id` attribute of the [Control element](/office/dev/add-in
 ```
 
 For this add-in button, the ID is `showInitContext`.
+
+---
 
 With these two pieces of information, we can create a basic `Action.InvokeAddInCommand` action as follows:
 


### PR DESCRIPTION
The manifest doesn't play any part in invoking an add-in from an actionable message. But the developer consults the manifest to get two pieces of information. This PR tells the developer how to do that if the add-in uses the unified manifest. 